### PR TITLE
feat(validate): error if provider casing is inconsistent

### DIFF
--- a/tools/validate.py
+++ b/tools/validate.py
@@ -30,6 +30,27 @@ def rule_slug_unique(data):
             seen.add(slug)
     return errors
 
+def rule_provider_casing_consistent(data):
+    column_name = "provider"
+    errors = []
+    seen = {}
+    for idx, item in enumerate(data):
+        column_value = item.get(column_name)
+        if column_value is None:
+            continue
+        normalized_spelling = column_value.lower().strip()
+        if normalized_spelling in seen.keys():
+            spellings_except_current = list(filter(lambda x: x != column_value, seen[normalized_spelling]))
+            if len(spellings_except_current) == 0:
+                continue
+            quoted_spellings = list(map(lambda x: f"'{x}'", spellings_except_current))
+            known_spellings = ", ".join(quoted_spellings)
+            errors.append(f"Item {idx}: Inconsistent casing for {column_name} '{column_value}': got {known_spellings} and '{column_value}'")
+        else:
+            seen[normalized_spelling] = set()
+        seen[normalized_spelling].add(column_value)
+    return errors
+
 def rule_action_buttons_is_list_of_links(data):
     errors = []
     for idx, item in enumerate(data):
@@ -108,6 +129,7 @@ def main():
     rules.add_rule(rule_slug_unique)
     rules.add_rule(rule_no_unclosed_markdown)
     rules.add_rule(rule_action_buttons_is_list_of_links)
+    rules.add_rule(rule_provider_casing_consistent)
 
     validator = Draft7Validator(schema)
     for network_spec in os.listdir("json"):


### PR DESCRIPTION
## Summary

To avoid duplicates while grouping in toolbox


## Type of change
- [ ] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only


## Scope
- **Networks affected**: (e.g., ethereum, polygon, arbitrum; or global)
- **Categories affected**: (e.g., rpc, wallet, explorer, indexing, bridge, analytic, devTool, oracle, faucet)
- **Cross-chain provider?** If yes, also updated `providers/` CSVs: [ ] Yes [ ] N/A

- Additional notes (constraints, naming, normalization), additional context / screenshots: 

## Links
- Related issue(s): (e.g., Closes #123)
- DB Improvement Proposal (DBIP), if schema-related: (e.g., #456)


## Validation checklist
- [ ] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [ ] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [ ] No duplicate entries (by provider + chain + relevant key columns)
- [ ] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [ ] Values match defined types/enums per Column Definitions
- [ ] No unintended whitespace, trailing commas, or empty lines


## Optional
- Rewards address (for data patching rewards):
