### PR TITLE
fix: exit with 1 when normalization fails

### DIFF
--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -144,7 +144,7 @@ def main():
             print(f"Errors while normalizing {network_name} JSON:")
             for error in errors:
                 print(error)
-            return 1
+            exit(1)
 
         os.makedirs('json', exist_ok=True)
         with(open(f"json/{network_name}.json", 'w+')) as f:

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -180,7 +180,7 @@ def main():
         print(f"Errors while normalizing providers JSON:")
         for error in errors:
             print(error)
-        return 1
+        exit(1)
     
     # Override provider schema so the chain field is not required
     provider_schema = copy.deepcopy(schema)


### PR DESCRIPTION
## Summary

Exit with 1 when normalization fails. It incorrectly exited with 0 before.


## Type of change
- [ ] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only


## Scope
- **Networks affected**: (e.g., ethereum, polygon, arbitrum; or global)
- **Categories affected**: (e.g., rpc, wallet, explorer, indexing, bridge, analytic, devTool, oracle, faucet)
- **Cross-chain provider?** If yes, also updated `providers/` CSVs: [ ] Yes [ ] N/A

- Additional notes (constraints, naming, normalization), additional context / screenshots: 

## Links
- Related issue(s): (e.g., Closes #123)
- DB Improvement Proposal (DBIP), if schema-related: (e.g., #456)


## Validation checklist
- [ ] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [ ] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [ ] No duplicate entries (by provider + chain + relevant key columns)
- [ ] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [ ] Values match defined types/enums per Column Definitions
- [ ] No unintended whitespace, trailing commas, or empty lines


## Optional
- Rewards address (for data patching rewards):
