### PR TITLE
Add contribution file to the directory root.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,6 @@
+# Style guide
+
 Detailed contribution guidelines is available in the project's [Wiki](../../wiki)
+
+# Grant program and rewards
+Please, check out our [Grant Program](../../discussions/41) - population of the database makes you eligible for USDT/USDC rewards under certain conditions.


### PR DESCRIPTION
## Summary

I think it is hard for our contributors to find a wiki as usually users expect to see the contributing doc. Let's add it, wouldn't harm anyways.


## Type of change
- [x] Documentation/metadata only


## Scope
- **Networks affected**: (e.g., ethereum, polygon, arbitrum; or global) none
- **Categories affected**: (e.g., rpc, wallet, explorer, indexing, bridge, analytic, devTool, oracle, faucet) none

- Additional notes (constraints, naming, normalization), additional context / screenshots: 


## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines