### PR TITLE
Add RPC endpoint for ethereum mainnet: Infura - Free

### DIFF
--- a/networks/ethereum/rpc.csv
+++ b/networks/ethereum/rpc.csv
@@ -37,3 +37,4 @@ chainnodes-hoodi-pay-as-you-go-archive,!provider:chainnodes-pay-as-you-go-full-a
 chainstack-mainnet-free,!provider:chainstack-free-recent-state,,,mainnet,,,,,,,,,,,,,,,,,
 chainstack-mainnet-pay-as-you-go-archive,!provider:chainstack-pay-as-you-go-full-archive,,,mainnet,,,,,,,,,,,,,,,,,
 chainstack-mainnet-enterprise-archive,!provider:chainstack-enterprise-full-archive,,,mainnet,,,,,,,,,,,,,,,,,
+infura-ethereum-mainnet-free,Infura,Free,Recent-State,mainnet,$0,$0,99.9%,10G/s,2,FALSE,TRUE,"[""eth"",""net"",""web3""]","[""20k requests daily cap"",""40 rps""]","[""DDoS Protection"",""IP Protection""]","[""Usage analytics"",""Request logs""]","[""US East"",""EU West""]",null,null,null,"[""[Signup](https://infura.io)"",""[Docs](https://docs.infura.io)""]",null


### PR DESCRIPTION
This PR adds a new RPC endpoint to the Chain-Love database for **ethereum mainnet**.

## Changes
- Added new RPC endpoint: **Infura** (Free)
- Network: **ethereum**
- Chain: **mainnet**
- File: `networks/ethereum/rpc.csv`

## RPC Details
- **Provider**: Infura
- **Plan**: Free
- **Node Type**: Recent-State
- **Chain**: mainnet

- **Access Price**: $0
- **Query Price**: $0
- **Uptime SLA**: 99.9%
- **Bandwidth SLA**: 10G/s
- **Blocks Behind SLA**: 2
- **Trial Available**: Yes

- **Available APIs**: eth, net, web3
- **Limitations**: 20k requests daily cap, 40 rps
- **Regions**: US East, EU West

## Guidelines Followed
- [x] Reviewed the [Style Guide](https://github.com/Chain-Love/chain-love/wiki/Style-Guide)
- [x] Used uppercase TRUE/FALSE for boolean values
- [x] Validated JSON columns
- [x] Checked existing entries for consistency

## Reference
- [RPC Column Definitions](https://github.com/Chain-Love/chain-love/wiki/RPC)