### PR TITLE
Add Analytics provider entry for Arkham

### DIFF
--- a/providers/analytics.csv
+++ b/providers/analytics.csv
@@ -1,0 +1,2 @@
+slug,provider,dataSources,hasDashboard,availableApis,price,starred,actionButtons
+arkham,Arkham,"[""test1"",""test1=2""]",TRUE,,"custo,",FALSE,


### PR DESCRIPTION
## Summary

Added Analytics data via the provider entry. Provider slug: `arkham`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: global
- **Categories affected**: analytics
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @hrsh22.

CSV preview:
```csv
arkham,Arkham,"[""test1"",""test1=2""]",TRUE,,"custo,",FALSE,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided