### PR TITLE
Modify Link Checker to add PR verification

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

If the PR is big it would be great to know if it doesn't contain broken links.


## Type of change
- [x] Documentation/metadata only


## Scope
- **Networks affected**: (e.g., ethereum, polygon, arbitrum; or global) global
- **Categories affected**: (e.g., rpc, wallet, explorer, indexing, bridge, analytic, devTool, oracle, faucet) global
