### PR TITLE
refactor: reorder analytic provider entries

### DIFF
--- a/providers/analytic.csv
+++ b/providers/analytic.csv
@@ -1,5 +1,4 @@
 slug,provider,dataSources,hasDashboard,availableApis,price,starred,actionButtons
-1rpc,1rpc,,FALSE,,,FALSE,
 arkham,Arkham,"[""Transactions"",""Active Users"",""Contracts"",""DApp Interactions""]",TRUE,"[""REST API"",""WebSocket API"",""Arkham Exchange API""]",Custom,FALSE,"[""[Dashboard](https://intel.arkm.com/dashboards/explore)""]"
 blockworks,Blockworks,"[""Network fees"",""Transaction activity"",""Contracts deployed"",""Tokens created"",""Retention rate"",""Economics per defi type"",""AI Agents"",""Stablecoins swaps"",""Meme coins""]",TRUE,"[""Data API"",""Supported Data Types"",""Additional Tools and Libraries""]",$0,FALSE,"[""[Dashboard](https://blockworks.com/analytics)""]"
 cid-checker,CID Checker,"[""Active Deals"",""Verified Deals""]",FALSE,"[""REST API""]",$0,FALSE,"[""[Dashboard](https://filecoin.tools/)""]"


### PR DESCRIPTION
## Summary

Added Analytic data via the provider entry. Provider slug: `1rpc`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: global
- **Categories affected**: analytic
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @eugene17kotov.

CSV preview:
```csv
1rpc,1rpc,,FALSE,,,FALSE,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided