### PR TITLE
Add Analytic network direct entry on mainnet

### DIFF
--- a/networks/hjfghfgh/analytic.csv
+++ b/networks/hjfghfgh/analytic.csv
@@ -1,0 +1,2 @@
+slug,provider,chain,dataSources,hasDashboard,availableApis,price,starred,actionButtons
+1rpc-mainnet,1rpc,mainnet,,FALSE,,,FALSE,


### PR DESCRIPTION
## Summary

Added Analytic data via the network-only entry. Network slug: `1rpc-mainnet`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: mainnet
- **Categories affected**: analytic
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @eugene17kotov.

CSV preview:
```csv
1rpc-mainnet,1rpc,mainnet,,FALSE,,,FALSE,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided