### PR TITLE
Add RPC Provider network direct entry on qweqweqw

### DIFF
--- a/networks/base/rpc.csv
+++ b/networks/base/rpc.csv
@@ -44,3 +44,4 @@ tenderly-enterprise-mainnet-recent-state,!provider:tenderly-enterprise-recent-st
 tenderly-free-testnet-recent-state,!provider:tenderly-free-recent-state,"[""[Website](https://tenderly.co/)"",""[Docs](https://docs.tenderly.co/supported-networks)""]",,,testnet,,,,,,,,,,,,,,,,
 tenderly-pay-as-you-go-testnet-recent-state,!provider:tenderly-pay-as-you-go-recent-state,"[""[Buy](https://tenderly.co/pricing)"",""[Docs](https://docs.tenderly.co/supported-networks)""]",,,testnet,,,,,,,,,,,,,,,,
 tenderly-enterprise-testnet-recent-state,!provider:tenderly-enterprise-recent-state,"[""[Contact](https://tenderly.co/pricing)"",""[Docs](https://docs.tenderly.co/supported-networks)""]",,,testnet,,,,,,,,,,,,,,,,
+qwerqwr-qweqweqw-dedicated-recent-state,qwerqwr,,Dedicated,Recent-State,qweqweqw,1,1,,,,99%,12,12,FALSE,FALSE,,,,,,


### PR DESCRIPTION
## Summary

Added RPC Provider data via the network-only entry. Network slug: `qwerqwr-qweqweqw-dedicated-recent-state`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: qweqweqw
- **Categories affected**: rpc
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @ArseniiPetrovich.

CSV preview:
```csv
qwerqwr-qweqweqw-dedicated-recent-state,qwerqwr,,Dedicated,Recent-State,qweqweqw,1,1,,,,99%,12,12,FALSE,FALSE,,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided