### PR TITLE
chore(ci): fix link checker image

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -29,7 +29,7 @@ jobs:
           docker run --rm \
             --network none \
             -v "${{ runner.temp }}/lychee-output:/output" \
-            ghcr.io/lycheeverse/lychee \
+            lycheeverse/lychee:latest-alpine \
             --output /output/out.md \
             --extensions csv \
             --accept 200,204,400,401,403,405,429 \


### PR DESCRIPTION
Seems that docker images behind link checker moved from ghcr to docker hub, so I think my change should fix that... Hopefully.