### PR TITLE
chore(ci): allow network access to lychee container

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -27,7 +27,6 @@ jobs:
         run: |
           # Run link checker
           docker run --rm \
-            --network none \
             -v "${{ runner.temp }}/lychee-output:/output" \
             lycheeverse/lychee:latest-alpine \
             --output /output/out.md \


### PR DESCRIPTION
Need to allow network access for the container, otherwise it won't be able to resolve `raw.githubusercontent.com`