### PR TITLE
Add Analytic network direct entry on base

### DIFF
--- a/networks/base/analytic.csv
+++ b/networks/base/analytic.csv
@@ -8,3 +8,4 @@ tokenterminal,!provider:tokenterminal,"[""[Dashboard](https://tokenterminal.com/
 growthepie-mainnet,!provider:growthepie,"[""[Dashboard](https://www.growthepie.com/chains/base)""]",mainnet,,,,,
 sentry-aleno-mainnet,!provider:sentry-aleno,"[""[Dashboard](https://docs.aleno.ai/supported-liquidity-sources#blockchains-dex-sources)""]",mainnet,,,,,
 jiffyscan-mainnet,!provider:jiffyscan,"[""[Dashboard](https://jiffyscan.xyz/?network=base)""]",mainnet,,,,,
+custom-provider-1-base,Custom provider 1,,base,,FALSE,,,FALSE


### PR DESCRIPTION
## Summary

Added Analytic data via the network-only entry. Network slug: `custom-provider-1-base`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: base
- **Categories affected**: analytic
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @vasylkivt.

CSV preview:
```csv
custom-provider-1-base,Custom provider 1,,base,,FALSE,,,FALSE
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided