### PR TITLE
remove infra word from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chain.Love Infrastructure Database
+# Chain.Love Web3 Database
 
 This repository documents blockchain service providers - RPCs, wallets, explorers, analytics, bridges, dev tools, faucets, oracles, indexing services, etc. - in a structured way.
 


### PR DESCRIPTION
## Summary

I think given the recent changes we are going through - having word "Infrastructure" in the title of our repo is highly misleading. The majority of the records we have are services, not infra, so I would just use Web3 buzzword instead. Agree?


## Type of change
- [x] Documentation/metadata only