### PR TITLE
Add Faucets provider entry for 1rpc

### DIFF
--- a/providers/faucets.csv
+++ b/providers/faucets.csv
@@ -20,3 +20,4 @@ rockx-faucet,RockX,,TRUE,FALSE,,$0,FALSE,,NULL,
 stakely-faucet,Stakely,"[""[Faucet](https://stakely.io/faucet)""]",FALSE,TRUE,,$0,FALSE,"[""Requires to make the tweet in X about requesting tokens"",""Need to have low or zero mainnet balance for asking mainnet tokens""]",,
 tatum-faucet,Tatum,,TRUE,FALSE,0.001 ETH,$0,FALSE,,0.002 ETH,
 thirdweb-faucet,ThirdWeb,"[""[Faucet](https://thirdweb.com/faucets)""]",TRUE,TRUE,,$5/month,FALSE,"[""Available only on paid plans""]",0.05 ETH,24h
+1rpc-faucet,1rpc,,FALSE,FALSE,,,FALSE,,,


### PR DESCRIPTION
## Summary

Added Faucets data via the provider entry. Provider slug: `1rpc-faucet`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: global
- **Categories affected**: faucets
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @eugene17kotov.

CSV preview:
```csv
1rpc-faucet,1rpc,,FALSE,FALSE,,,FALSE,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided