### PR TITLE
ci: creare a workflow to release JSONs

### DIFF
--- a/.github/workflows/release-json.yaml
+++ b/.github/workflows/release-json.yaml
@@ -23,7 +23,7 @@ jobs:
           for file in json/*.json; do
             filename=$(basename "$file")
             schema_version=$(jq -r '.shcemaVersion // "1.0.0"' "$file")
-            new_name="schema-${schema_version}-${filename}"
+            new_name="schema-${schema_version}-${filename}.json"
             cp "$file" "release-assets/$new_name"
           done
 


### PR DESCRIPTION
`1.0.0` is currently used as the default (initial) schema version. Future releases will derive the version from the `schemaVersion` field in the JSON files.