### PR TITLE
Add APIs provider entry for Chainstack

### DIFF
--- a/.github/workflows/release-json.yaml
+++ b/.github/workflows/release-json.yaml
@@ -1,0 +1,40 @@
+name: Release JSONs
+
+on:
+  workflow_run:
+    workflows: [CSV to JSON]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: json
+
+      - name: Prepare release assets
+        id: prep
+        run: |
+          mkdir -p release-assets
+          for file in json/*.json; do
+            filename=$(basename "$file")
+            schema_version=$(jq -r '.shcemaVersion // "1.0.0"' "$file")
+            new_name="schema-${schema_version}-${filename}"
+            cp "$file" "release-assets/$new_name"
+          done
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="json-release-${GITHUB_SHA::7}"
+          gh release create "$tag" release-assets/* \
+            --title "JSON (${GITHUB_SHA::7})" \
+            --notes "Automated release from json branch"


### PR DESCRIPTION
## Summary

Added APIs data via the provider entry. Provider slug: `chainstack-free-ethereum`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: global
- **Categories affected**: apis
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @Yassinesayahlembarek.

CSV preview:
```csv
chainstack-free-ethereum,Chainstack,"[""[Website](https://chainstack.com/)"",""[Docs](https://docs.chainstack.com/)""]",Developer,Free,Pruned,EVM JSON-RPC,Ethereum,0$,,,,,99.9%,,,,FALSE,FALSE,"[""WebSockets"",""Debug APIs"",""Archive Nodes""]",,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `networks/<chain>/<category>.csv` for chain-scoped entries
  - `providers/<category>.csv` when the provider/service is chain-agnostic or cross-chain
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided