### PR TITLE
simplify json release process

### DIFF
--- a/.github/workflows/release-json.yaml
+++ b/.github/workflows/release-json.yaml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [CSV to JSON]
     types: [completed]
+  workflow_dispatch: 
 
 permissions:
   contents: write


### PR DESCRIPTION
- Drop schema version from JSON filenames to simplify naming
- Introduce deterministic release tags for consistent versioning