### PR TITLE
Extend APIs listing on mainnet

### DIFF
--- a/listings/specific-networks/base/apis.csv
+++ b/listings/specific-networks/base/apis.csv
@@ -196,3 +196,4 @@ thirdweb-mainnet-free-indexer,,!offer:thirdweb-free-indexer,"[""[Website](https:
 thirdweb-mainnet-pay-as-you-go-indexer,,!offer:thirdweb-pay-as-you-go-indexer,"[""[Buy](https://thirdweb.com/pricing)"",""[Docs](https://portal.thirdweb.com/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 thirdweb-testnet-free-indexer,,!offer:thirdweb-free-indexer,"[""[Website](https://thirdweb.com/base-sepolia-testnet)"",""[Docs](https://portal.thirdweb.com/)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
 thirdweb-testnet-pay-as-you-go-indexer,,!offer:thirdweb-pay-as-you-go-indexer,"[""[Buy](https://thirdweb.com/pricing)"",""[Docs](https://portal.thirdweb.com/)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+1rpc-public-recent-state-mainnet,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Added APIs data via the listing entry referencing offer. Network slug: `1rpc-public-recent-state-mainnet`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: mainnet
- **Categories affected**: APIs
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @eugene17kotov.

CSV preview:
```csv
1rpc-public-recent-state-mainnet,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `listings/specific-networks/<chain>/<category>.csv` for chain-scoped entries
  - `references/offers/<category>.csv` for offer entries
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided