### PR TITLE
Extend APIs listing on mainnet

### DIFF
--- a/listings/specific-networks/base/apis.csv
+++ b/listings/specific-networks/base/apis.csv
@@ -4,6 +4,7 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-pay-as-you-go-recent-state,,!offer:1rpc-pay-as-you-go-recent-state,"[""[Buy](https://www.1rpc.io/#pricing)"",""[Docs](https://docs.1rpc.io/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,"[""[Website](https://www.1rpc.io/)"",""[Docs](https://docs.1rpc.io/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-testnet-pay-as-you-go-recent-state,,!offer:1rpc-pay-as-you-go-recent-state,"[""[Buy](https://www.1rpc.io/#pricing)"",""[Docs](https://docs.1rpc.io/)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+alchemy-enterprise-full-archive-mainnet,,!offer:alchemy-enterprise-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 alchemy-free-recent-state-mainnet,,!offer:alchemy-free-recent-state,"[""[Website](https://www.alchemy.com/rpc/base)"", ""[Docs](https://www.alchemy.com/docs/reference/base-api-quickstart)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 alchemy-free-recent-state-testnet,,!offer:alchemy-free-recent-state,"[""[Website](https://www.alchemy.com/rpc/base-sepolia)"", ""[Docs](https://www.alchemy.com/docs/choosing-a-web3-network#base-sepolia-testnet)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
 alchemy-pay-as-you-go-recent-state-mainnet,,!offer:alchemy-pay-as-you-go-recent-state,"[""[Buy](https://www.alchemy.com/pricing)"", ""[Docs](https://www.alchemy.com/docs/reference/base-api-quickstart)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Added APIs data via the listing entry referencing offer. Network slug: `alchemy-enterprise-full-archive-mainnet`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: mainnet
- **Categories affected**: APIs
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @eugene17kotov.

CSV preview:
```csv
alchemy-enterprise-full-archive-mainnet,,!offer:alchemy-enterprise-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `listings/specific-networks/<chain>/<category>.csv` for chain-scoped entries
  - `references/offers/<category>.csv` for offer entries
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided