### PR TITLE
Extend Oracles listing on any another shit

### DIFF
--- a/listings/specific-networks/base/oracles.csv
+++ b/listings/specific-networks/base/oracles.csv
@@ -1,6 +1,7 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 api3-mainnet,,!offer:api3,"[""[Docs](https://docs.api3.org/)""]",mainnet,,,,,,,,,,,,
 api3-testnet,,!offer:api3,"[""[Docs](https://docs.api3.org/)""]",testnet,,,,,,,,,,,,
+band-any-another-shit,,!offer:band,,any another shit,,,,,,,,,,,,
 chainlink-mainnet,,!offer:chainlink,"[""[ETH/USD](https://data.chain.link/feeds/base/base/eth-usd)"", ""[Docs](https://docs.chain.link/)""]",mainnet,,,,,,,,,,,,
 chainlink-testnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/)""]",testnet,,,,,,,,,,,,
 chronicle-mainnet,,!offer:chronicle,"[""[ETH/USD](https://chroniclelabs.org/dashboard/oracle/ETH/USD#blockchain=BASE)""]",mainnet,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Added Oracles data via the listing entry referencing offer. Network slug: `band-any-another-shit`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: any another shit
- **Categories affected**: Oracles
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @Igor2698.

CSV preview:
```csv
band-any-another-shit,,!offer:band,,any another shit,,,,,,,,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `listings/specific-networks/<chain>/<category>.csv` for chain-scoped entries
  - `references/offers/<category>.csv` for offer entries
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided