### PR TITLE
feat(validate-csv): if a field contains a url, the field must be quoted

### DIFF
--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -2,6 +2,9 @@ from pathlib import Path
 from typing import Iterator, Callable, List, Dict
 import os
 import csv
+import re
+
+URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
 
 Rule = Callable[[Path, List[Dict[str, str]]], List[str]]
 
@@ -47,6 +50,49 @@ def rule_slug_sorted(path: Path, rows: List[Dict[str, str]]) -> List[str]:
 
     return errors
 
+def rule_links_must_be_quoted(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    errors: List[str] = []
+
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception as e:
+        return [f"{path}: read error during link quoting validation: {e}"]
+
+    if not raw_lines:
+        return []
+
+    for lineno, raw_line in enumerate(raw_lines, start=1):
+        # Parse properly using CSV parser
+        parsed_fields = next(csv.reader([raw_line]))
+
+        cursor = 0
+        for field in parsed_fields:
+            field_stripped = field.strip()
+
+            # Locate this field in the raw line
+            # We search from current cursor forward
+            idx = raw_line.find(field, cursor)
+            if idx == -1:
+                continue
+
+            # Determine if it was quoted
+            was_quoted = (
+                idx > 0
+                and idx + len(field) < len(raw_line)
+                and raw_line[idx - 1] == '"'
+                and raw_line[idx + len(field)] == '"'
+            )
+
+            if field_stripped and URL_PATTERN.search(field_stripped):
+                if not was_quoted:
+                    errors.append(
+                        f"{path}: row {lineno}: URL field must be quoted: {field_stripped}"
+                    )
+
+            cursor = idx + len(field)
+
+    return errors
+
 def iter_csv_files(root: Path) -> Iterator[Path]:
     for dirpath, _, filenames in os.walk(root):
         for name in sorted(filenames):
@@ -58,6 +104,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []
 


### PR DESCRIPTION
Just so we don't mistake a CSV comma as a part of URL.