### PR TITLE
fix(schema): replace 'oneOf' with 'examples' for planType fields in schema.json

### DIFF
--- a/tools/schema.json
+++ b/tools/schema.json
@@ -589,9 +589,14 @@
         "description": { "type": ["string", "null"] },
         "planName": { "type": ["string", "null"] },
         "planType": {
-          "oneOf": [
-            { "type": "string", "enum": ["Free", "Pay-as-you-go", "Enterprise", "Dedicated", "Tiered", "One-time payment"] },
-            { "type": "string" }
+          "type": "string",
+          "examples": [
+            "Free",
+            "Pay-as-you-go",
+            "Enterprise",
+            "Dedicated",
+            "Tiered",
+            "One-time payment"
           ]
         },
         "price": { "type": ["string", "null"] },
@@ -680,9 +685,14 @@
         "description": { "type": ["string", "null"] },
         "tag": { "type": ["array", "null"], "items": { "type": "string" } },
         "planType": {
-          "oneOf": [
-            { "type": "string", "enum": ["Free", "Pay-as-you-go", "Enterprise", "Dedicated", "Tiered", "One-time payment"] },
-            { "type": "string" }
+          "type": "string",
+          "examples": [
+            "Free",
+            "Pay-as-you-go",
+            "Enterprise",
+            "Dedicated",
+            "Tiered",
+            "One-time payment"
           ]
         },
         "planName": { "type": ["string", "null"] },


### PR DESCRIPTION
- Updated schema.json to enhance clarity by replacing 'oneOf' constructs with 'examples' for the planType field, improving validation and usability of the schema.