### PR TITLE
fix: replace dead Chainup Cloud website link

### DIFF
--- a/references/providers/providers.csv
+++ b/references/providers/providers.csv
@@ -108,7 +108,7 @@ chainport,ChainPort,chainport.png,Provides cross-chain bridge services for Web3 
 chainsafe,ChainSafe,chainsafe.png,A javascript client library for building Zcash browser wallets,https://github.com/ChainSafe/WebZjs,,,ChainSafe/WebZjs,,,,,FALSE,
 chainspot,Chainspot,chainspot.png,Provides cross-chain bridge services for Web3 developers and users.,https://app.chainspot.io/,https://docs.chainspot.io/,,,,,,,FALSE,
 chainstack,Chainstack,chainstack.png,Provides API infrastructure and faucet services for Web3 developers and users.,https://faucet.chainstack.com/,https://docs.chainstack.com/docs/platform-introduction,,,,,,,FALSE,
-chainup-cloud,Chainup Cloud,chainup-cloud.png,Provides API infrastructure for Web3 developers and users.,http://filecoin-calibration.chainup.net/rpc/v1,https://docs.chainupcloud.com/blockchain-api/filecoin/public-apis,,,,,,,FALSE,
+chainup-cloud,Chainup Cloud,chainup-cloud.png,Provides API infrastructure for Web3 developers and users.,https://cloud.chainup.com/,https://docs.chainupcloud.com/blockchain-api/filecoin/public-apis,,,,,,,FALSE,
 chronicle-protocol,Chronicle Protocol,chronicle-protocol.png,Provides oracle services for Web3 developers and users.,,,,,,,,,FALSE,
 cid-checker,CID Checker,cid-checker.png,Provides analytics products for Web3 developers and users.,https://filecoin.tools/,,,,,,,,FALSE,
 cinko,CiNKO,cinko.png,Provides wallet solutions for Web3 developers and users.,https://cinko.io/,,,,,,,,FALSE,


### PR DESCRIPTION
## Summary
- updates `references/providers/providers.csv` for `chainup-cloud`
- replaces dead `website` URL (`http://filecoin-calibration.chainup.net/rpc/v1`, returns 404) with official ChainUp Cloud site `https://cloud.chainup.com/`

## Why this is safe
- one-field, one-row fix in canonical provider metadata
- no schema changes, no new entities, no inferred data
- keeps provider docs URL unchanged
- diff is 1 line changed (under 100-line limit)

## Verification
- old website URL: 404
- new website URL: 200
- provider docs page: 200 and references ChainUp Cloud + official signup at `cloud.chainup.com`

## Sources
- ChainUp Cloud docs home: https://docs.chainupcloud.com/
- ChainUp Cloud Filecoin docs: https://docs.chainupcloud.com/blockchain-api/filecoin/public-apis
- ChainUp Cloud official site: https://cloud.chainup.com/
