### PR TITLE
fix(ci): prevent link-check failure on empty extracted diff

### DIFF
--- a/.github/workflows/link-check-analysis.yaml
+++ b/.github/workflows/link-check-analysis.yaml
@@ -56,6 +56,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
+          failIfEmpty: false
           args: >
             --extensions csv
             --accept 200,204,400,401,403,405,429


### PR DESCRIPTION
## Summary
- set `failIfEmpty: false` for `lycheeverse/lychee-action@v2` in `.github/workflows/link-check-analysis.yaml`
- keeps existing `fail: false` behavior and prevents false-negative failures when PR-added content materialization yields no CSV links to scan

## Why
The failing run for PR #956 shows Lychee input `failIfEmpty: true`, which can fail the job when the materialized PR additions folder has no files/links for Lychee to check.

## Scope
- CI workflow only
- 1-line change
