### PR TITLE
add(monad): add canonical ramps listings from official Monad tooling

### DIFF
--- a/listings/specific-networks/monad/ramps.csv
+++ b/listings/specific-networks/monad/ramps.csv
@@ -1,0 +1,8 @@
+slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
+banxa,,!offer:banxa,,,,,,,,
+meld,,!offer:meld,,,,,,,,
+mercuryo,,!offer:mercuryo,,,,,,,,
+moonpay,,!offer:moonpay,,,,,,,,
+onramper,,!offer:onramper,,,,,,,,
+ramp-network,,!offer:ramp-network,,,,,,,,
+transak,,!offer:transak,,,,,,,,


### PR DESCRIPTION
## Summary

Add `listings/specific-networks/monad/ramps.csv` with 7 canonical ramp offers (`banxa`, `meld`, `mercuryo`, `moonpay`, `onramper`, `ramp-network`, `transak`) to cover a currently missing Monad category.

Why this is needed:
- Monad currently has no `ramps.csv` listings despite official Monad tooling docs listing supported on/off-ramp providers.
- Adding this file materially improves Monad usability for end users looking for fiat entry/exit options.

Why this is safe:
- Every added row references an existing canonical offer via `!offer:<slug>`.
- Added providers are explicitly marked as supported (`✅`) in Monad’s official onramps page.
- No schema or structure changes.

Sources used:
- Monad official docs (Onramps): https://docs.monad.xyz/tooling-and-infra/onramps
- Canonical ramp offers in repo: `references/offers/ramps.csv`

Why this candidate was chosen:
- High value-to-risk: fills an entirely missing Monad category with official-source-backed canonical entries.
- Coherent one-theme patch and easy to review.

Why broader alternatives were not chosen:
- Wider Monad multi-category expansion (explorers/oracles/etc.) would require adding new canonical offers/providers and a larger verification surface in one PR.
- This PR keeps the strongest verified subset from official Monad docs and stays tightly auditable.

Open-PR overlap check:
- I reviewed all currently open PRs authored by `USS-Contributor` in `Chain-Love/chain-love` before selecting this work.
- None of those PRs add or modify `listings/specific-networks/monad/ramps.csv`.
- Therefore this contribution does not overlap my still-open PRs.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change <!-- (requires linked DBIP below) -->
- [ ] Documentation/metadata only


## Scope
- Networks affected: monad
- Categories affected: ramps

- Additional notes, additional context / screenshots:
  - New file is intentionally limited to providers with both:
    1) explicit Monad support status in official Monad docs (`✅`), and
    2) existing canonical offers in `references/offers/ramps.csv`.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
<!-- Please ensure you understand everything and agrees with what is written below. Violations may result in reward slashes of database grant population program -->

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address (for data patching rewards): 
- Twitter (X) post link (for +10% of rewards to this PR):

​​​​​​​​​​
