### PR TITLE
add(sui): add canonical oracle listings for pyth, supra, and switchboard

### DIFF
--- a/listings/specific-networks/sui/oracles.csv
+++ b/listings/specific-networks/sui/oracles.csv
@@ -1,0 +1,7 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+pyth-mainnet,,!offer:pyth,"[""[Docs](https://docs.pyth.network/price-feeds/core/contract-addresses/sui)""]",mainnet,,,,,,,,,,,,
+pyth-testnet,,!offer:pyth,"[""[Docs](https://docs.pyth.network/price-feeds/core/contract-addresses/sui)""]",testnet,,,,,,,,,,,,
+supra-mainnet,,!offer:supra,"[""[Docs](https://docs.supra.com/oracles/data-feeds/pull-oracle#sui)""]",mainnet,,,,,,,,,,,,
+supra-testnet,,!offer:supra,"[""[Docs](https://docs.supra.com/oracles/data-feeds/pull-oracle#sui)""]",testnet,,,,,,,,,,,,
+switchboard-mainnet,,!offer:switchboard,"[""[Docs](https://docs.switchboard.xyz/docs-by-chain/sui)""]",mainnet,,,,,,,,,,,,
+switchboard-testnet,,!offer:switchboard,"[""[Docs](https://docs.switchboard.xyz/docs-by-chain/sui)""]",testnet,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add a new `listings/specific-networks/sui/oracles.csv` file with canonical oracle listings for **Pyth**, **Supra**, and **Switchboard** on Sui (mainnet + testnet where documented).

Why this is needed:
- Sui is a priority bounty network in Discussion #41.
- Sui currently had no `oracles.csv` listing file.
- This adds a coherent, directly user-facing coverage improvement in one category with official docs-backed references.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change <!-- (requires linked DBIP below) -->
- [ ] Documentation/metadata only


## Scope
- Networks affected: `sui`
- Categories affected: `oracles`

- Additional notes, additional context / screenshots:
  - Added 6 rows:
    - `pyth-mainnet`, `pyth-testnet`
    - `supra-mainnet`, `supra-testnet`
    - `switchboard-mainnet`, `switchboard-testnet`
  - All rows use `!offer:<slug>` references to existing canonical offers in `references/offers/oracles.csv`.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A
- Discussion #41 (priority alignment): https://github.com/Chain-Love/chain-love/discussions/41

## Sources used (official)
- Pyth Sui contract addresses (includes Sui mainnet/testnet sections):
  - https://docs.pyth.network/price-feeds/core/contract-addresses/sui
- Supra Pull Oracle docs (Sui tab + mainnets/testnets tables):
  - https://docs.supra.com/oracles/data-feeds/pull-oracle#sui
- Switchboard Sui docs (Sui page with mainnet/testnet sections):
  - https://docs.switchboard.xyz/docs-by-chain/sui

## Why this is safe
- Uses existing canonical offer slugs only (`pyth`, `supra`, `switchboard`), no schema changes.
- Adds one coherent file in one network/category slice.
- Links are official provider docs pages.
- No inferred pricing/features were added in listing overrides (only documented network availability and docs links).

## Candidate selection notes
- Considered broader candidates (e.g., Sui wallets and wider multi-category expansions), but skipped due weaker or slower-to-verify official evidence for all fields.
- Selected this candidate because it has:
  1. strong official evidence,
  2. high user value (new Sui oracle coverage),
  3. clean thematic coherence,
  4. straightforward reviewability.

## Non-overlap check against my own open PRs
I re-checked all currently open PRs authored by `USS-Contributor` before opening this PR:
- #960, #966, #972, #973, #975, #976

None touch `listings/specific-networks/sui/oracles.csv` or this Sui-oracles initiative, so this change does **not** overlap existing open work.

## Validation checklist
<!-- Please ensure you understand everything and agrees with what is written below. Violations may result in reward slashes of database grant population program -->

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address (for data patching rewards):
- Twitter (X) post link (for +10% of rewards to this PR):
​​​​​​​​​​