### PR TITLE
Add missing MCP listings for AgentKit and Wallet Agent on EVM networks

### DIFF
--- a/listings/specific-networks/astar/mcpservers.csv
+++ b/listings/specific-networks/astar/mcpservers.csv
@@ -1,3 +1,4 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,
 universal-crypto-mcp,,!offer:universal-crypto-mcp,,,,,,,,,,,,,,,,
 wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/blast/mcpservers.csv
+++ b/listings/specific-networks/blast/mcpservers.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,
 evm-mcp-server,,!offer:evm-mcp-server,,,,,,,,,,,,,,,,
 universal-crypto-mcp,,!offer:universal-crypto-mcp,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/fantom/mcpservers.csv
+++ b/listings/specific-networks/fantom/mcpservers.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,
 evm-mcp-server,,!offer:evm-mcp-server,,,,,,,,,,,,,,,,
 universal-crypto-mcp,,!offer:universal-crypto-mcp,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/linea/mcpservers.csv
+++ b/listings/specific-networks/linea/mcpservers.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
 3xpl-mcp,,!offer:3xpl-mcp,,,,,,,,,,,,,,,,
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,
 evm-mcp-server,,!offer:evm-mcp-server,,,,,,,,,,,,,,,,
 ucai,,!offer:ucai,,,,,,,,,,,,,,,,
 universal-crypto-mcp,,!offer:universal-crypto-mcp,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/mantle/mcpservers.csv
+++ b/listings/specific-networks/mantle/mcpservers.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,
 evm-mcp-server,,!offer:evm-mcp-server,,,,,,,,,,,,,,,,
 universal-crypto-mcp,,!offer:universal-crypto-mcp,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/scroll/mcpservers.csv
+++ b/listings/specific-networks/scroll/mcpservers.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,
 evm-mcp-server,,!offer:evm-mcp-server,,,,,,,,,,,,,,,,
 universal-crypto-mcp,,!offer:universal-crypto-mcp,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

This PR improves MCP coverage by adding missing EVM-network listings for two existing MCP offers that explicitly support EVM-compatible networks:

- `coinbase-agentkit-mcp` added to: `astar`, `blast`, `fantom`, `linea`, `mantle`, `scroll`
- `wallet-agent` added to: `blast`, `fantom`, `mantle`, `scroll`

Why this is needed:
- AgentKit docs state support for deployment on any EVM-compatible network (plus Solana).
- Wallet Agent docs state support for adding any EVM-compatible chain via custom chain configuration.
- The affected network docs describe these networks as EVM-compatible / Ethereum-equivalent / zkEVM targets.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change <!-- (requires linked DBIP below) -->
- [ ] Documentation/metadata only


## Scope
- Networks affected: astar, blast, fantom, linea, mantle, scroll
- Categories affected: mcpservers

- Additional notes, additional context / screenshots:
  - MCP-only change (no non-MCP files touched)
  - Diff size: 6 files changed, 10 insertions

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A
- Evidence used:
  - AgentKit support scope: https://docs.cdp.coinbase.com/agent-kit/welcome
  - Wallet Agent support scope: https://github.com/wallet-agent/wallet-agent
  - Astar EVM docs: https://docs.astar.network/
  - Blast EVM-compatible docs: https://docs.blast.io/about-blast.md
  - Fantom EVM compatibility docs: https://docs.fantom.foundation/build-on-opera/overview.md
  - Linea Ethereum-equivalent zkEVM: https://linea.build/
  - Mantle EVM-compatible docs: https://docs.mantle.xyz/network/
  - Scroll zkEVM: https://scroll.io/

## Validation checklist
<!-- Please ensure you understand everything and agrees with what is written below. Violations may result in reward slashes of database grant population program -->

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address (for data patching rewards):
- Twitter (X) post link (for +10% of rewards to this PR):
​​​​​​​​​​