### PR TITLE
add(ramps): add MoonPay and Transak listings for Sui and TON

### DIFF
--- a/listings/specific-networks/sui/ramps.csv
+++ b/listings/specific-networks/sui/ramps.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
+moonpay,,!offer:moonpay,"[""[Buy](https://www.moonpay.com/buy/sui)""]",,,,,,,
+transak,,!offer:transak,"[""[Buy](https://transak.com/buy/sui)""]",,,,,,,

--- a/listings/specific-networks/ton/ramps.csv
+++ b/listings/specific-networks/ton/ramps.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
+moonpay,,!offer:moonpay,"[""[Buy](https://www.moonpay.com/buy/ton)""]",,,,,,,
+transak,,!offer:transak,"[""[Buy](https://transak.com/buy/ton)""]",,,,,,,


### PR DESCRIPTION
## What changed
This PR adds missing `ramps` listings for two priority networks that currently had no ramps coverage:
- `listings/specific-networks/sui/ramps.csv` (new)
- `listings/specific-networks/ton/ramps.csv` (new)

Each file includes canonical `!offer` rows for two existing ramps offers:
- `moonpay`
- `transak`

I also set network-specific `actionButtons` with direct buy pages for each network/token.

## Why this is safe
- Uses existing canonical offers from `references/offers/ramps.csv` (`!offer:moonpay`, `!offer:transak`), so no new provider/offer entities were introduced.
- Purely additive change (2 new files, 6 added lines total).
- Follows existing ramps schema/header and listing reference pattern.
- Rows are slug-sorted (A→Z).

## Sources used (official)
- MoonPay Sui buy page: https://www.moonpay.com/buy/sui
- MoonPay TON buy page: https://www.moonpay.com/buy/ton
- Transak Sui buy page: https://transak.com/buy/sui
- Transak TON buy page: https://transak.com/buy/ton
- Bounty/discussion priority context (#41): https://github.com/Chain-Love/chain-love/discussions/41

## Why this was the best candidate
I prioritized a coherent, high-confidence growth patch that:
1. Adds missing category coverage (ramps) for two Discussion #41 priority networks (Sui + TON),
2. Uses strong, directly verifiable official sources,
3. Stays easy to review in one sitting.

## Why broader/alternative candidates were not chosen
- **Broader ramps expansion (more providers)** was not chosen because several provider coverage pages were JS-heavy / not cleanly verifiable from stable official text in this environment.
- **Monad/Polygon exploratory additions** were skipped for this run where evidence was weaker or less complete than this Sui+TON set.
- **Provider metadata batches** were skipped because my own open PRs already cover provider metadata slices.

## Non-overlap confirmation (my currently open PRs)
Checked live open PRs by `USS-Contributor` before selecting scope:
- #989, #986: `references/providers/providers.csv`
- #988: MCP listings (CryptoAPIs address-latest coverage)
- #987: `monad/explorers.csv`
- #966: `monad/oracles.csv`

This PR does **not** overlap those open scopes/files.
