### PR TITLE
add(sui/wallets): add 5 officially documented wallet listings

### DIFF
--- a/listings/specific-networks/sui/wallets.csv
+++ b/listings/specific-networks/sui/wallets.csv
@@ -1,0 +1,6 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+binance-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
+ledger,,!offer:ledger,,,,,,,,,,,,,,,,,,,
+martian-wallet,,!offer:martian-wallet,,,,,,,,,,,,,,,,,,,
+okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+phantom,,!offer:phantom,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Add a new `listings/specific-networks/sui/wallets.csv` file with 5 canonical wallet listings (`!offer` references) that are explicitly described as Sui wallet options in official Sui Foundation blog content.

Added rows:
- `binance-wallet`
- `ledger`
- `martian-wallet`
- `okxwallet`
- `phantom`

This materially improves Sui coverage because Sui previously had no wallets category file in `listings/specific-networks/sui/`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change <!-- (requires linked DBIP below) -->
- [ ] Documentation/metadata only


## Scope
- Networks affected: `sui`
- Categories affected: `wallets`

- Additional notes, additional context / screenshots:
  - All listing rows use canonical `!offer:<slug>` references that already exist in `references/offers/wallets.csv`.
  - No provider metadata, schema, or cross-category files were modified.
  - Slugs are A→Z sorted.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Why this candidate was selected
I evaluated multiple candidate initiatives and selected this one because it had the best value-to-risk ratio:
- **High user/database value**: fills a missing Sui wallets listing file (new usable category coverage).
- **Strong official evidence**: wallet support statements come from official Sui Foundation blog posts.
- **High coherence/reviewability**: one file, one theme, canonical `!offer` references only.
- **Low overlap risk**: no overlap with my currently open PRs (which are on MCP, ramps, provider URL/docs fixes, and Monad APIs).

## Candidates considered but not chosen
- **Sonic/Somnia ramps expansion**: skipped (already covered by my open PR #1020).
- **Additional MCP expansion**: skipped (already covered by my open PRs #992, #1008, #1019, #1022).
- **Sui explorers expansion**: skipped for this run due weaker canonical alignment (most Sui explorers in official ecosystem sources are not yet represented as existing canonical explorer offers in this repo, which would require a larger new-provider/new-offer addition with more evidence collection).

## Sources used (official)
- Sui Foundation blog: wallet options on Sui (mentions Binance custodial wallet option, Phantom, Ledger hardware wallets)  
  https://blog.sui.io/wallet-options-on-sui/
- Sui Foundation blog: commonly used wallets in Sui ecosystem (mentions OKX Wallet, Phantom, Martian Wallet)  
  https://blog.sui.io/unlock-sui-with-the-right-wallet/

## Safety notes
- Every added listing row references an existing canonical wallet offer slug.
- No speculative fields were filled; only `slug` + `offer` reference entries were added.
- No schema or structural changes.
- The contribution is a single coherent initiative and remains easy to audit in one sitting.
- Confirmed non-overlap with my own still-open PRs before selecting this candidate.

## Validation checklist
<!-- Please ensure you understand everything and agrees with what is written below. Violations may result in reward slashes of database grant population program -->

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address (for data patching rewards): 
- Twitter (X) post link (for +10% of rewards to this PR):
