### PR TITLE
feat(arbitrum): populate storages category with 5 canonical offers

### DIFF
--- a/listings/specific-networks/arbitrum/storages.csv
+++ b/listings/specific-networks/arbitrum/storages.csv
@@ -1,0 +1,6 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planType,planName,description,starred
+arweave,,!offer:arweave,,,,,,,,
+irys,,!offer:irys,,,,,,,,
+lighthouse,,!offer:lighthouse,,,,,,,,
+pinata,,!offer:pinata,,,,,,,,
+storacha,,!offer:storacha,,,,,,,,


### PR DESCRIPTION
## Summary
Continue network-population campaign on **Arbitrum** by filling the missing `storages` category with canonical offer references.

Added 5 storage listings in `listings/specific-networks/arbitrum/storages.csv`:
- `!offer:arweave`
- `!offer:irys`
- `!offer:lighthouse`
- `!offer:pinata`
- `!offer:storacha`

## Why this chunk
Arbitrum was already above threshold in all other categories, and `storages` was the only missing category for campaign sufficiency.

## Sources (official)
- Arweave docs: https://docs.arweave.org/developers
- Irys docs: https://docs.irys.xyz/
- Lighthouse docs: https://docs.lighthouse.storage/
- Pinata docs: https://docs.pinata.cloud/
- Storacha docs: https://docs.storacha.network/
