### PR TITLE
feat(morph): add bridges, apis, explorers, and oracles listings

### DIFF
--- a/listings/specific-networks/morph/apis.csv
+++ b/listings/specific-networks/morph/apis.csv
@@ -1,0 +1,12 @@
+slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,verifiedUptime,verifiedLatency,verifiedBlocksBehindAvg,uptimeSla,bandwidthSla,blocksBehindSla,supportSla,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag
+drpc-mainnet-free-recent-state,,!offer:drpc-free-recent-state,"[""[Website](https://drpc.org/chainlist/morph-mainnet-rpc)"",""[Docs](https://drpc.org/docs)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+drpc-mainnet-pay-as-you-go-recent-state,,!offer:drpc-pay-as-you-go-recent-state,"[""[Buy](https://drpc.org/pricing)"",""[Docs](https://drpc.org/docs)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,"[""[Access](https://morph.drpc.org)"",""[Docs](https://drpc.org/docs)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-accelerate-full-archive,,!offer:quicknode-accelerate-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-accelerate-recent-state,,!offer:quicknode-accelerate-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-build-full-archive,,!offer:quicknode-build-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-business-full-archive,,!offer:quicknode-business-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-business-recent-state,,!offer:quicknode-business-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-scale-full-archive,,!offer:quicknode-scale-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-scale-recent-state,,!offer:quicknode-scale-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/morph/bridges.csv
+++ b/listings/specific-networks/morph/bridges.csv
@@ -1,0 +1,12 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+crosscurve,,!offer:crosscurve,,mainnet,,,,,,,,,,,,,,,,,,
+hyperlane,,!offer:hyperlane,,mainnet,,,,,,,,,,,,,,,,,,
+layerswap,,!offer:layerswap,,mainnet,,,,,,,,,,,,,,,,,,
+meson,,!offer:meson,,mainnet,,,,,,,,,,,,,,,,,,
+orbiter,,!offer:orbiter,,mainnet,,,,,,,,,,,,,,,,,,
+owlto,,!offer:owlto,,mainnet,,,,,,,,,,,,,,,,,,
+pheasant,,!offer:pheasant,,mainnet,,,,,,,,,,,,,,,,,,
+rubic,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,
+smolrefuel,,!offer:smolrefuel,,mainnet,,,,,,,,,,,,,,,,,,
+stargate,,!offer:stargate,,mainnet,,,,,,,,,,,,,,,,,,
+symbiosis,,!offer:symbiosis,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/morph/explorers.csv
+++ b/listings/specific-networks/morph/explorers.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,starred,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.morph.network/)""]",mainnet,,,,,,,,,,,
+tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/morph)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/morph/oracles.csv
+++ b/listings/specific-networks/morph/oracles.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+pyth-mainnet,,!offer:pyth,"[""[Docs](https://docs.pyth.network/price-feeds/contract-addresses/evm)""]",mainnet,,,,,,,,,,,,


### PR DESCRIPTION
## What changed

Adds initial developer-tool listings for the **Morph** EVM L2 network across 4 categories:

- **bridges.csv** (11 rows): CrossCurve, Hyperlane, LayerSwap, Meson, Orbiter, Owlto, Pheasant, Rubic, SmolRefuel, Stargate, Symbiosis
- **apis.csv** (11 rows): dRPC (free/pay-as-you-go/public) and QuickNode (Accelerate/Build/Business/Scale × full-archive/recent-state)
- **explorers.csv** (2 rows): Blockscout (explorer.morph.network), Tenderly
- **oracles.csv** (1 row): Pyth Network (mainnet, confirmed deployed per official Morph docs)

Total diff: 29 insertions across 4 new files.

## Why this is safe

Every entry was verified against official sources:

- **Bridges**: Each slug is a known offer in `references/offers/bridges.csv`. Bridge support for Morph confirmed from the respective providers' own bridge UIs or supported-chain lists.
- **dRPC**: `https://drpc.org/chainlist/morph-mainnet-rpc` (HTTP 200, live)
- **QuickNode**: `https://www.quicknode.com/chains/morph` (HTTP 200, live)
- **Explorers**: `https://explorer.morph.network/` and `https://dashboard.tenderly.co/explorer/morph` both return HTTP 200
- **Pyth**: Official Morph developer docs explicitly state "Pyth is deployed on Morph Mainnet, check the contract" at `https://docs.morph.network/docs/build-on-morph/developer-resources/use-ecosystem-developer-tools/blockchain-oracles`. Pyth EVM contract address page lists "Morph" as a supported mainnet.

All files pass:
- ✓ column count matches reference headers
- ✓ slug A-Z ordering
- ✓ all `!offer:` slugs exist in `references/offers/*.csv`
- ✓ no slug conflicts with `listings/all-networks/` files

## Sources used

- https://docs.morph.network/docs/build-on-morph/developer-resources/use-ecosystem-developer-tools/blockchain-oracles (official Morph oracle docs)
- https://www.quicknode.com/chains/morph (QuickNode chain page)
- https://drpc.org/chainlist/morph-mainnet-rpc (dRPC chain listing)
- https://explorer.morph.network/ (official Morph Blockscout explorer)
- https://dashboard.tenderly.co/explorer/morph (Tenderly Morph explorer)
- https://docs.pyth.network/price-feeds/contract-addresses/evm (Pyth EVM addresses, Morph listed as mainnet)

## Why this candidate

Morph is a live EVM L2 network with an active ecosystem and zero prior coverage in the database. The network has good multi-provider API support (QuickNode + dRPC), multiple bridges, two explorers, and a confirmed oracle (Pyth). All four categories have clean, verifiable evidence.

**Why not broader**: eOracle (the only other oracle mentioned in Morph's docs) is "in the process of integrating" — not yet deployed. No other oracle has official Morph mainnet evidence. Faucet would require adding new provider/offer references, which is out of scope for this PR.

## No overlap with open PRs

I checked all open USS-Contributor PRs before submission. No existing open PR covers Morph in any category.
