### PR TITLE
feat(fraxtal): add initial bridges listings from canonical offers

### DIFF
--- a/listings/specific-networks/fraxtal/bridges.csv
+++ b/listings/specific-networks/fraxtal/bridges.csv
@@ -1,0 +1,12 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+axelar,,!offer:axelar,,mainnet,,,,,,,,,,,,,,,,,,
+chainspot,,!offer:chainspot,,mainnet,,,,,,,,,,,,,,,,,,
+crosscurve,,!offer:crosscurve,,mainnet,,,,,,,,,,,,,,,,,,
+hyperlane,,!offer:hyperlane,,mainnet,,,,,,,,,,,,,,,,,,
+jumper,,!offer:jumper,,mainnet,,,,,,,,,,,,,,,,,,
+orbiter,,!offer:orbiter,,mainnet,,,,,,,,,,,,,,,,,,
+rubic,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,
+smolrefuel,,!offer:smolrefuel,,mainnet,,,,,,,,,,,,,,,,,,
+squid,,!offer:squid,,mainnet,,,,,,,,,,,,,,,,,,
+stargate,,!offer:stargate,,mainnet,,,,,,,,,,,,,,,,,,
+symbiosis,,!offer:symbiosis,,mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
Added a new network-specific bridges listing file:
- `listings/specific-networks/fraxtal/bridges.csv`

This file adds 11 canonical `!offer:` bridge listings on `chain=mainnet`:
`axelar`, `chainspot`, `crosscurve`, `hyperlane`, `jumper`, `orbiter`, `rubic`, `smolrefuel`, `squid`, `stargate`, `symbiosis`.

## Why this is safe
- Every added listing references an existing canonical offer in `references/offers/bridges.csv`.
- For each added slug, `supportedChains` includes `"fraxtal"` in the canonical offer row.
- No schema/policy changes.
- Diff is small and reviewable (1 new CSV file, 12 inserted lines).
- Chain logo requirement is already satisfied in this folder (`mainnet.png` already exists).

## Sources used
Primary canonical source:
- `references/offers/bridges.csv` (existing canonical rows + `supportedChains` for each slug)

Official bridge/docs links (from canonical offer `actionButtons`):
- Axelar: https://www.axelar.network/ , https://docs.axelar.dev/
- Chainspot: https://app.chainspot.io/ , https://docs.chainspot.io/
- CrossCurve: https://app.crosscurve.fi/ , https://docs.crosscurve.fi
- Hyperlane: https://www.hyperlane.xyz/ , https://docs.hyperlane.xyz/
- Jumper: https://jumper.exchange/ , https://jumper.exchange/learn
- Orbiter: https://orbiter.finance , https://docs.orbiter.finance
- Rubic: https://rubic.exchange , https://docs.rubic.finance/
- SmolRefuel: https://smolrefuel.com , https://docs.smolrefuel.com
- Squid: https://app.squidrouter.com/ , https://docs.squidrouter.com
- Stargate: https://stargate.finance/ , https://stargateprotocol.gitbook.io/stargate/
- Symbiosis: https://app.symbiosis.finance/ , https://docs.symbiosis.finance/

## Why this was the best candidate
- Fraxtal currently had no category CSV listings despite already having chain logos in-place.
- This is a coherent, single-theme improvement: **initial Fraxtal bridge coverage from existing canonical offers**.
- High value-to-risk ratio: meaningful user-facing coverage increase with strongly constrained, reference-backed edits.

## Why broader/alternative candidates were not chosen
- Broader multi-category or multi-network expansions were deprioritized this run to keep verification confidence and reviewability high.
- Overlapping slices with my still-open PRs were avoided (see overlap note below).

## Open-PR overlap check
Checked still-open PRs by `USS-Participator` (#1313–#1319). This PR does **not** overlap concrete scope:
- no same file paths,
- no same network/category slice,
- no same intended repair.
