### PR TITLE
feat(bridges): add initial canonical listings for cardano, dash, dogecoin, litecoin, and xrpl

### DIFF
--- a/listings/specific-networks/cardano/bridges.csv
+++ b/listings/specific-networks/cardano/bridges.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
+chainport-mainnet,,!offer:chainport,,mainnet,,,,,,,,,,,,,,,,,,
+rubic-mainnet,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,
+wanchain-mainnet,,!offer:wanchain,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/dash/bridges.csv
+++ b/listings/specific-networks/dash/bridges.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
+rubic-mainnet,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/dogecoin/bridges.csv
+++ b/listings/specific-networks/dogecoin/bridges.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
+wanchain-mainnet,,!offer:wanchain,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/litecoin/bridges.csv
+++ b/listings/specific-networks/litecoin/bridges.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
+rubic-mainnet,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,
+wanchain-mainnet,,!offer:wanchain,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/xrpl/bridges.csv
+++ b/listings/specific-networks/xrpl/bridges.csv
@@ -1,0 +1,5 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
+axelar-mainnet,,!offer:axelar,,mainnet,,,,,,,,,,,,,,,,,,
+smolrefuel-mainnet,,!offer:smolrefuel,,mainnet,,,,,,,,,,,,,,,,,,
+squid-mainnet,,!offer:squid,,mainnet,,,,,,,,,,,,,,,,,,
+wormhole-mainnet,,!offer:wormhole,,mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Add initial `bridges.csv` listings for five underrepresented network folders that already have `mainnet.png` but no bridges coverage:
- `cardano`
- `dash`
- `dogecoin`
- `litecoin`
- `xrpl`

This adds 11 canonical `!offer` bridge rows total, all `chain=mainnet`.

## What changed
Created:
- `listings/specific-networks/cardano/bridges.csv` (3 rows)
- `listings/specific-networks/dash/bridges.csv` (1 row)
- `listings/specific-networks/dogecoin/bridges.csv` (1 row)
- `listings/specific-networks/litecoin/bridges.csv` (2 rows)
- `listings/specific-networks/xrpl/bridges.csv` (4 rows)

## Why this is safe
- Every added listing references an existing canonical bridge offer via `!offer:<slug>`.
- For each row, `references/offers/bridges.csv` already includes the target network in `supportedChains`.
- Only new network-local listing files were added; no canonical offer/provider edits.
- Existing network logo requirements are already satisfied (`mainnet.png` already present in all five folders).
- Validation passed for all touched files:
  - `python3 /tmp/validate_csv_new.py listings/specific-networks/{cardano,dash,dogecoin,litecoin,xrpl}/bridges.csv`
  - slug ordering checks (`sort -c`) passed.

## Sources used
- Repository canonical source of truth:
  - `references/offers/bridges.csv` (`slug` + `supportedChains`)
  - Existing network folders under `listings/specific-networks/*` for chain/logo compatibility

## Why this candidate was selected
This was the best value-to-risk option in this run:
- materially improves coverage across **five** sparse network folders in one coherent theme
- uses strong canonical evidence already present in-repo
- low ambiguity and low regression risk
- easy to review (5 files, 16 added lines)

## Why broader/alternative candidates were not chosen
- Broader bridge expansions touching networks tied to still-open PRs were skipped to avoid concrete overlap:
  - #1327 (bitcoin bridges)
  - #1320 (fraxtal bridges)
  - #1324 (aptos/filecoin/sonic bridges)
- Provider-social and MCP batches were not chosen because that slice is already heavily represented by my still-open PRs (#1316, #1323, #1326, #1329 and #1314/#1318/#1322/#1325/#1328).
- Higher-ambiguity candidates requiring new canonical offers were rejected in favor of this fully canonical, evidence-backed pack.

## Overlap confirmation
Confirmed no concrete overlap with my still-open PR scopes/files (author `USS-Participator` open PRs inspected live before selection).
