### PR TITLE
feat(bridges): add canonical initial listings for sei, iotex, and tezos

### DIFF
--- a/listings/specific-networks/iotex/bridges.csv
+++ b/listings/specific-networks/iotex/bridges.csv
@@ -1,1 +1,0 @@
-slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag

--- a/listings/specific-networks/iotex/bridges.csv
+++ b/listings/specific-networks/iotex/bridges.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+meson,,!offer:meson,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/iotex/bridges.csv
+++ b/listings/specific-networks/iotex/bridges.csv
@@ -1,2 +1,1 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
-meson,,!offer:meson,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/sei/bridges.csv
+++ b/listings/specific-networks/sei/bridges.csv
@@ -1,0 +1,13 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+axelar,,!offer:axelar,,mainnet,,,,,,,,,,,,,,,,,,
+debridge,,!offer:debridge,,mainnet,,,,,,,,,,,,,,,,,,
+hyperlane,,!offer:hyperlane,,mainnet,,,,,,,,,,,,,,,,,,
+interport,,!offer:interport,,mainnet,,,,,,,,,,,,,,,,,,
+jumper,,!offer:jumper,,mainnet,,,,,,,,,,,,,,,,,,
+layerswap,,!offer:layerswap,,mainnet,,,,,,,,,,,,,,,,,,
+meson,,!offer:meson,,mainnet,,,,,,,,,,,,,,,,,,
+okutrade,,!offer:okutrade,,mainnet,,,,,,,,,,,,,,,,,,
+smolrefuel,,!offer:smolrefuel,,mainnet,,,,,,,,,,,,,,,,,,
+squid,,!offer:squid,,mainnet,,,,,,,,,,,,,,,,,,
+stargate,,!offer:stargate,,mainnet,,,,,,,,,,,,,,,,,,
+transporter,,!offer:transporter,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/tezos/bridges.csv
+++ b/listings/specific-networks/tezos/bridges.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+rubic,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds initial `bridges.csv` listings for three existing specific-network folders using canonical `!offer` references from `references/offers/bridges.csv`:

- `listings/specific-networks/sei/bridges.csv` (12 listings)
- `listings/specific-networks/iotex/bridges.csv` (1 listing)
- `listings/specific-networks/tezos/bridges.csv` (1 listing)

Added slugs:
- sei: `axelar`, `debridge`, `hyperlane`, `interport`, `jumper`, `layerswap`, `meson`, `okutrade`, `smolrefuel`, `squid`, `stargate`, `transporter`
- iotex: `meson`
- tezos: `rubic`

## Why this is safe
- Every added row uses canonical `!offer:<slug>` references (no freeform provider facts introduced).
- Every added slug was verified to already exist in `references/offers/bridges.csv`.
- For each row, `supportedChains` in canonical offers explicitly includes the target network (`sei`, `iotex`, `tezos`).
- No schema/structure changes.
- Validation passed:
  - `python3 /tmp/validate_csv_new.py listings/specific-networks/sei/bridges.csv`
  - `python3 /tmp/validate_csv_new.py listings/specific-networks/iotex/bridges.csv`
  - `python3 /tmp/validate_csv_new.py listings/specific-networks/tezos/bridges.csv`
  - slug ordering checks (`sort -c`) passed for all three files.

## Sources used
- Canonical offers dataset in this repository:
  - `references/offers/bridges.csv` (slug existence + `supportedChains` evidence)
- Repository contribution docs/rules:
  - `AGENTS.md`
  - `CONTRIBUTING.md`

## Why this was the best candidate
- High evidence strength: all facts are backed by existing canonical references in-repo.
- Material improvement: adds 14 bridge listings across three underdeveloped network slices in one coherent initiative.
- Low risk and reviewable scope: 3 files, 17 inserted lines, no speculative data.

## Why broader/alternative candidates were not chosen
- **Broader “fill all missing bridges” variant** included networks without explicit canonical support in `supportedChains` (e.g., `bitcoin-cash`, `ethereum-classic`, `kaspa`, `stacks`) and was narrowed to avoid speculation.
- **Provider social/link batches** require per-provider live source verification and had lower value-to-risk for this run compared with canonical bridge completion.
- **MCP expansion variants** had higher overlap risk with my currently open MCP PR set.

## Overlap check
Checked open PRs authored by USS contributor identities before selection:
- `USS-Contributor`: none open
- `USS-Participator`: open PRs include provider-social, MCP, logo, and other bridge slices (`bitcoin`, `fraxtal`, `cardano/dash/dogecoin/litecoin/xrpl`, etc.)

This PR does **not** overlap concrete scope/rows with those open PRs (different network/category rows).