### PR TITLE
fix(bitcoin-cash): align analytics column schema with canonical order

### DIFF
--- a/listings/specific-networks/bitcoin-cash/analytics.csv
+++ b/listings/specific-networks/bitcoin-cash/analytics.csv
@@ -1,6 +1,6 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,availableApis,price,planName,planType,starred,tag
-santiment-business-max,,!offer:santiment-business-max,,mainnet,,,,,,,,
-santiment-business-pro,,!offer:santiment-business-pro,,mainnet,,,,,,,,
-santiment-free,,!offer:santiment-free,,mainnet,,,,,,,,
-santiment-sanbase-max,,!offer:santiment-sanbase-max,,mainnet,,,,,,,,
-santiment-sanbase-pro,,!offer:santiment-sanbase-pro,,mainnet,,,,,,,,
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+santiment-business-max,,!offer:santiment-business-max,,mainnet,,,,,,,,,
+santiment-business-pro,,!offer:santiment-business-pro,,mainnet,,,,,,,,,
+santiment-free,,!offer:santiment-free,,mainnet,,,,,,,,,
+santiment-sanbase-max,,!offer:santiment-sanbase-max,,mainnet,,,,,,,,,
+santiment-sanbase-pro,,!offer:santiment-sanbase-pro,,mainnet,,,,,,,,,


### PR DESCRIPTION
## What changed
- normalized `listings/specific-networks/bitcoin-cash/analytics.csv` header to match canonical analytics schema by inserting `historicalData` between `hasDashboard` and `availableApis`
- shifted the five Santiment listing rows to keep field alignment with the corrected 14-column header

## Why this is safe
- structural-only fix (no provider/offer/slug/url value changes)
- keeps existing `!offer:` references intact
- scope is one file / one network / one category

## Evidence
- canonical analytics schema in `references/offers/analytics.csv` and `listings/all-networks/analytics.csv` includes `historicalData` in this position

## Validation
- `python3 /tmp/validate_csv_new.py listings/specific-networks/bitcoin-cash/analytics.csv` **blocked**: script missing in runtime (`/tmp/validate_csv_new.py` not found)
- row-width sanity check: pass (all rows 14 columns)
- slug ordering check: pass
- `!offer` linkage check against `references/offers/analytics.csv`: pass
