### PR TITLE
feat(bridges): close canonical gaps for flare, astar, lens, and stellar

### DIFF
--- a/listings/specific-networks/astar/bridges.csv
+++ b/listings/specific-networks/astar/bridges.csv
@@ -1,4 +1,8 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
 celer-astar,,!offer:celer,,astar,,,,,,,,,,,,,,,,,,
 celer-shiden,,!offer:celer,,shiden,,,,,,,,,,,,,,,,,,
+chainlink-bridge-astar,,!offer:chainlink-bridge,,astar,,,,,,,,,,,,,,,,,,
+hyperlane-astar,,!offer:hyperlane,,astar,,,,,,,,,,,,,,,,,,
+interport-astar,,!offer:interport,,astar,,,,,,,,,,,,,,,,,,
+smolrefuel-astar,,!offer:smolrefuel,,astar,,,,,,,,,,,,,,,,,,
 wanchain-bridge-astar,,!offer:wanchain,,astar,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/flare/bridges.csv
+++ b/listings/specific-networks/flare/bridges.csv
@@ -1,4 +1,10 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+enosys-bridge-mainnet,,!offer:enosys-bridge,,mainnet,,,,,,,,,,,,,,,,,,
+hyperlane-mainnet,,!offer:hyperlane,,mainnet,,,,,,,,,,,,,,,,,,
+interport-mainnet,,!offer:interport,,mainnet,,,,,,,,,,,,,,,,,,
+jumper-mainnet,,!offer:jumper,,mainnet,,,,,,,,,,,,,,,,,,
 layerzero-mainnet,,!offer:layerzero,,mainnet,,,,,,,,,,,,,,,,,,
+rubic-mainnet,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,
+smolrefuel-mainnet,,!offer:smolrefuel,,mainnet,,,,,,,,,,,,,,,,,,
 stargate-mainnet,,!offer:stargate,,mainnet,,,,,,,,,,,,,,,,,,
 zkbridge-mainnet,,!offer:zkbridge,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/lens/bridges.csv
+++ b/listings/specific-networks/lens/bridges.csv
@@ -1,6 +1,10 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
 across-mainnet,,!offer:across,,mainnet,,,,,,,,,,,,,,,,,,
 across-testnet,,!offer:across,,testnet,,,,,,,,,,,,,,,,,,
+jumper-mainnet,,!offer:jumper,,mainnet,,,,,,,,,,,,,,,,,,
 lensbridge-mainnet,Lens,,"[""[Bridge](https://lens.xyz/bridge)"",""[Docs](https://lens.xyz/docs/chain/tools/bridging/lens)""]",mainnet,Cross-chain Messaging,null,null,FALSE,"[""Discord"",""Email""]",TRUE,"[""Cross-chain Messaging"",""Asset Transfer""]","[""Custom Dashboards""]","[""Lens Protocol Integration"",""Fast Bridging""]","[""GHO"",""ETH"",""USDC"",""USDT"",""ERC-20"",""ERC-721""]",Gas Fee,TRUE,Inherits Lens Network security,"[""Audit by Trail of Bits, 2024""]",Decentralized,"[""Solidity""]",,
+okutrade-mainnet,,!offer:okutrade,,mainnet,,,,,,,,,,,,,,,,,,
+owlto-mainnet,,!offer:owlto,,mainnet,,,,,,,,,,,,,,,,,,
+smolrefuel-mainnet,,!offer:smolrefuel,,mainnet,,,,,,,,,,,,,,,,,,
 zksync-mainnet,Zksync,,"[""[Bridge](https://bridge.zksync.io/)"",""[Docs](https://lens.xyz/docs/chain/tools/bridging/zksync)""]",mainnet,ZK Rollup,null,null,FALSE,"[""Discord"",""Email""]",TRUE,"[""Asset Transfer""]","[""Blockscout"",""Custom Dashboards""]","[""ZK Rollup Security"",""Ethereum Security""]","[""GHO"",""ETH"",""USDC"",""USDT""]",Gas Fee,TRUE,Inherits Ethereum security,"[""Multiple audits by OpenZeppelin, 2023""]",Decentralized,"[""Solidity""]",,
 zksync-testnet,Zksync,,"[""[Bridge](https://portal.testnet.lens.dev/bridge/)"",""[Docs](https://lens.xyz/docs/chain/tools/bridging/zksync)""]",testnet,ZK Rollup,null,null,FALSE,"[""Discord"",""Email""]",FALSE,"[""Asset Transfer""]","[""Blockscout"",""Custom Dashboards""]","[""ZK Rollup Security"",""Ethereum Sepolia Security""]","[""GRASS"",""ETH"",""USDC"",""USDT""]",Gas Fee,TRUE,Inherits Ethereum Sepolia security,"[""Multiple audits by OpenZeppelin, 2023""]",Decentralized,"[""Solidity""]",,

--- a/listings/specific-networks/stellar/bridges.csv
+++ b/listings/specific-networks/stellar/bridges.csv
@@ -1,3 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
 allbridge-mainnet,,!offer:allbridge-core,,mainnet,,,,,,,,,,,,,,,,,,
 allbridge-testnet,,!offer:allbridge-core,,testnet,,,,,,,,,,,,,,,,,,
+axelar-mainnet,,!offer:axelar,,mainnet,,,,,,,,,,,,,,,,,,
+rubic-mainnet,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,
+squid-mainnet,,!offer:squid,,mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
Expanded underrepresented `bridges.csv` coverage for four networks by adding canonical `!offer:` rows that are already marked as supported in `references/offers/bridges.csv`:

- `listings/specific-networks/flare/bridges.csv` (+6)
  - `enosys-bridge`, `hyperlane`, `interport`, `jumper`, `rubic`, `smolrefuel`
- `listings/specific-networks/astar/bridges.csv` (+4)
  - `chainlink-bridge`, `hyperlane`, `interport`, `smolrefuel`
- `listings/specific-networks/lens/bridges.csv` (+4)
  - `jumper`, `okutrade`, `owlto`, `smolrefuel`
- `listings/specific-networks/stellar/bridges.csv` (+3)
  - `axelar`, `rubic`, `squid`

Total: **17 new canonical bridge listings** across one coherent initiative.

## Why this is safe
- Listings-only change (no provider/offers schema edits).
- Every new row uses existing canonical `!offer:<slug>` linkage.
- Added rows are limited to offers whose canonical `supportedChains` includes the target network.
- Slug ordering preserved in each touched file.
- CSV validation passed for all touched files.

Validation run:
- `python3 /tmp/validate_csv.py` on all 4 touched CSVs ✅
- slug ordering checks (`sort -c`) ✅
- CSV reader width sanity checks ✅
- custom `!offer` existence + `supportedChains` inclusion checks ✅

## Sources used
- Canonical repository source of truth: `references/offers/bridges.csv` (`supportedChains` + canonical offer slugs).
- Existing per-network listing schemas in:
  - `listings/specific-networks/flare/bridges.csv`
  - `listings/specific-networks/astar/bridges.csv`
  - `listings/specific-networks/lens/bridges.csv`
  - `listings/specific-networks/stellar/bridges.csv`

## Why this candidate
Among current low-overlap options, this had the best value-to-risk profile: one focused PR that materially improves bridge discoverability in four underfilled network slices without introducing new providers/offers.

Pre-change gap size (from canonical support mapping):
- flare: 6 missing
- astar: 4 missing
- lens: 4 missing
- stellar: 3 missing

## Why broader/alternative candidates were not chosen
- **Broader multi-network bridge sweep**: deferred to keep review blast radius small and maintain a single crisp theme.
- **Provider metadata batches**: currently high collision risk with many open provider-table PRs; this bridge slice had cleaner overlap risk.
- **Files touched by my still-open PRs** (`#1381`, `#1385`, `#1391`, `#1393`, `#1397`): intentionally avoided.

## Overlap check (required)
Confirmed no concrete overlap with my still-open PRs. This PR touches only:
- `flare/bridges.csv`
- `astar/bridges.csv`
- `lens/bridges.csv`
- `stellar/bridges.csv`

None of these files are touched in my open PR set (`#1381`, `#1385`, `#1391`, `#1393`, `#1397`).
