### PR TITLE
fix(base/explorers): normalize explorers column order to canonical schema

### DIFF
--- a/listings/specific-networks/base/explorers.csv
+++ b/listings/specific-networks/base/explorers.csv
@@ -1,8 +1,8 @@
-slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,starred,tag
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 arkham-mainnet,,!offer:arkham,,mainnet,,,,,,,,,,,
 blockscout-sepolia,,!offer:blockscout,"[""[Explore](https://base-sepolia.blockscout.com/)""]",sepolia,,,,,,,,,,,
-dexguru-mainnet,Dex.Guru,,"[""[Explore](https://base.dex.guru/)"",""[Docs](https://dexguru.readme.io/docs/getting-started)""]",mainnet,Custom,"[""Transactions"",""Blocks"",""Account balances""]","[""Verify contracts"",""Debug transactions"",""Interactive trace""]","[""REST""]",,"[""Address"",""Transaction Hash"",""Block"",""Token""]",TRUE,TRUE,Free/$199/mo,FALSE,
+dexguru-mainnet,Dex.Guru,,"[""[Explore](https://base.dex.guru/)"",""[Docs](https://dexguru.readme.io/docs/getting-started)""]",mainnet,Custom,"[""Transactions"",""Blocks"",""Account balances""]","[""Verify contracts"",""Debug transactions"",""Interactive trace""]",FALSE,"[""REST""]",,"[""Address"",""Transaction Hash"",""Block"",""Token""]",TRUE,TRUE,Free/$199/mo,
 etherscan-sepolia,,!offer:etherscan,"[""[Explore](https://sepolia.basescan.org/)""]",sepolia,,,,,,,,,,,
 oklink-mainnet,,!offer:oklink,"[""[Explore](https://www.oklink.com/base)""]",mainnet,,,,,,,,,,,
-routescan-mainnet,Routescan,,"[""[Explore](https://routescan.io/)"",""[Docs](https://routescan.io/documentation/api/etherscan-like/accounts)""]",mainnet,Custom,"[""Transactions"",""Addresses"",""Tokens"",""Prices""]","[""Cross-chain"",""Superchain coverage""]","[""REST""]","[""TypeScript, Node.js""]","[""Address"",""Transaction Hash"",""Token"",""Price"",""Block""]",TRUE,TRUE,Free/$199/mo,FALSE,
+routescan-mainnet,Routescan,,"[""[Explore](https://routescan.io/)"",""[Docs](https://routescan.io/documentation/api/etherscan-like/accounts)""]",mainnet,Custom,"[""Transactions"",""Addresses"",""Tokens"",""Prices""]","[""Cross-chain"",""Superchain coverage""]",FALSE,"[""REST""]","[""TypeScript, Node.js""]","[""Address"",""Transaction Hash"",""Token"",""Price"",""Block""]",TRUE,TRUE,Free/$199/mo,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,,mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Normalize one schema-drifted file: `listings/specific-networks/base/explorers.csv` now matches canonical explorers column order used by `references/offers/explorers.csv` (`...additionalFeatures,starred,availableApis,...`).

## Why
The Base explorers listing had `starred` placed after `pricing`, which drifted from canonical explorers schema and risks field remapping during downstream JSON generation.

## Safety
- Single file, single theme
- No new data added
- Only column-order normalization with row value realignment for two populated rows (`dexguru-mainnet`, `routescan-mainnet`) to preserve semantics

## Validation
- `python3 /tmp/validate_csv_new.py listings/specific-networks/base/explorers.csv`
- CSV row-width check via Python `csv.reader` (all rows width=16)
- Slug ordering check (`sort -c`)
- Provider-linkage check for non-empty providers in file (`Dex.Guru`, `Routescan`)
