### PR TITLE
fix(celo/mcpservers): restore missing canonical schema columns

### DIFF
--- a/listings/specific-networks/celo/mcpservers.csv
+++ b/listings/specific-networks/celo/mcpservers.csv
@@ -1,3 +1,3 @@
-slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
-blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,
-nansen-mcp,,!offer:nansen-mcp,,,,,,,,,,,,,,,,
+slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
+nansen-mcp,,!offer:nansen-mcp,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Align `listings/specific-networks/celo/mcpservers.csv` header with the canonical MCP listing schema used in `listings/all-networks/mcpservers.csv`.

## What changed
- Added missing columns in-place (header only):
  - `credentialKey`
  - `selfHostedCommand`
  - `selfHostedArgs`
  - `selfHostedRequiredEnvVars`
- Preserved existing rows/slugs and semantics (`!offer` links unchanged).

## Why
The previous header omitted self-hosted/auth-related schema columns, creating category schema drift and reducing consistency for downstream consumers.

## Validation
- `python3 /tmp/validate_csv_new.py listings/specific-networks/celo/mcpservers.csv`
- Row-width sanity check (all rows now 23 columns)
- Slug ordering check (`sort -c`)
- Provider-linkage check (no non-canonical provider values)

This PR is intentionally narrow: one file, one schema-consistency fix.
