### PR TITLE
fix(unichain/mcpservers): restore missing canonical schema columns

### DIFF
--- a/listings/specific-networks/unichain/mcpservers.csv
+++ b/listings/specific-networks/unichain/mcpservers.csv
@@ -1,3 +1,3 @@
-slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
-blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,
-nansen-mcp,,!offer:nansen-mcp,,,,,,,,,,,,,,,,
+slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
+nansen-mcp,,!offer:nansen-mcp,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- restore `listings/specific-networks/unichain/mcpservers.csv` header to canonical MCP schema (23 columns)
- add the four missing structural columns (`credentialKey`, `selfHostedCommand`, `selfHostedArgs`, `selfHostedRequiredEnvVars`)
- preserve existing row intent (`!offer` references unchanged)

## Why this is safe
- structural-only change: no slug/provider/offer/action-target modifications
- aligns this file with canonical MCP headers used in `references/offers/mcpservers.csv` and `listings/all-networks/mcpservers.csv`
- limited to one file and one consistency theme

## Validation
- `python3 /tmp/validate_csv_new.py listings/specific-networks/unichain/mcpservers.csv`
- row-width check via `csv.reader` (all rows match header width)
- slug ordering check (`cut -d, -f1 listings/specific-networks/unichain/mcpservers.csv | tail -n +2 | sort -c`)
- provider-linkage check (no explicit provider mismatches)
