### PR TITLE
fix(services): align Sui/Zcash column order to canonical schema

### DIFF
--- a/listings/specific-networks/sui/services.csv
+++ b/listings/specific-networks/sui/services.csv
@@ -1,1 +1,1 @@
-slug,provider,offer,actionButtons,toolType,tag,price,planType,planName,description,starred
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred

--- a/listings/specific-networks/zcash/services.csv
+++ b/listings/specific-networks/zcash/services.csv
@@ -1,3 +1,3 @@
-slug,provider,offer,actionButtons,toolType,tag,price,planType,planName,description,starred
-2miners,2Miners,,"[""[Website](https://2miners.com/zec-mining-pool)""]",Finance,"[""PoW"",""Mining"",""Payouts""]",1% Fee,Pay-as-you-go,,User-friendly Zcash mining pool with regular payouts and robust monitoring tools,FALSE
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+2miners,2Miners,,"[""[Website](https://2miners.com/zec-mining-pool)""]",Finance,"[""PoW"",""Mining"",""Payouts""]",1% Fee,,Pay-as-you-go,User-friendly Zcash mining pool with regular payouts and robust monitoring tools,FALSE
 nowpayments,,!offer:nowpayments,"[""[Website](https://nowpayments.io/supported-coins/zcash-payments)""]",,,,,,,


### PR DESCRIPTION
## Summary
Align `services.csv` header order in two specific-network slices (`sui`, `zcash`) with the canonical services schema used across the repository.

## What changed
- `listings/specific-networks/sui/services.csv`
  - Reordered header columns from `price,planType,planName,...` to canonical `price,planName,planType,...`.
- `listings/specific-networks/zcash/services.csv`
  - Reordered the same header columns to canonical order.
  - Swapped the corresponding `2miners` row values between `planName` and `planType` so field meaning remains unchanged after header normalization.

## Why
This removes schema/header-order drift inside one tightly scoped category (`services`) and improves consistency for downstream CSV->JSON mapping and contributor usability.

## Validation
- `python3 /tmp/validate_csv_new.py listings/specific-networks/sui/services.csv`
- `python3 /tmp/validate_csv_new.py listings/specific-networks/zcash/services.csv`
- Python CSV row-width check on both touched files (all rows match header width)
- Slug ordering check:
  - `cut -d, -f1 listings/specific-networks/zcash/services.csv | tail -n +2 | sort -c`
- Canonical provider-linkage check against `references/providers/providers.csv` (touched rows resolve)

Diff size: 2 files, 3 insertions, 3 deletions.
