### PR TITLE
feat(hyperliquid): populate new network across bridges/apis/wallets

### DIFF
--- a/listings/specific-networks/hyperliquid/apis.csv
+++ b/listings/specific-networks/hyperliquid/apis.csv
@@ -2,5 +2,7 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-developer-recent-state,,!offer:chainstack-developer-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-free-recent-state,,!offer:drpc-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+drpc-mainnet-pay-as-you-go-recent-state,,!offer:drpc-pay-as-you-go-recent-state,"[""[Website](https://drpc.org/chainlist/hyperliquid-mainnet-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,"[""[Website](https://drpc.org/chainlist/hyperliquid-mainnet-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 onfinality-mainnet-developer-full-archive,,!offer:onfinality-developer-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/hyperliquid/wallets.csv
+++ b/listings/specific-networks/hyperliquid/wallets.csv
@@ -1,4 +1,4 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
-metamask-mainnet,,!offer:metamask,,,,,,,,,,,,,,,,,,,
-phantom-mainnet,,!offer:phantom,,,,,,,,,,,,,,,,,,,
-rabby-mainnet,,!offer:rabby,,,,,,,,,,,,,,,,,,,
+metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
+phantom,,!offer:phantom,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/hyperliquid/wallets.csv
+++ b/listings/specific-networks/hyperliquid/wallets.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+metamask-mainnet,,!offer:metamask,,,,,,,,,,,,,,,,,,,
+phantom-mainnet,,!offer:phantom,,,,,,,,,,,,,,,,,,,
+rabby-mainnet,,!offer:rabby,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed\n- Added  with 7 canonical bridge offers\n- Added  with 6 strongly-evidenced API entries\n- Added  with 3 canonical wallet offers\n- Included required  logo\n\n## Why this is safe\n- Single-network scoped change (hyperliquid only)\n- Canonical  linkage preserved for bridge/wallet rows\n- CSV validation + ordering/row-width checks passed\n\n## Sources\n- Hyperliquid docs (HyperEVM / onboarding / API endpoints)\n- dRPC Hyperliquid chain page\n- Canonical offers in 