### PR TITLE
feat(story): add initial infra partners listings pack

### DIFF
--- a/listings/specific-networks/story/apis.csv
+++ b/listings/specific-networks/story/apis.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/story/oracles.csv
+++ b/listings/specific-networks/story/oracles.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+gelato-mainnet,,!offer:gelato,,mainnet,,,,,,,,,,,,
+pyth-mainnet,,!offer:pyth,,mainnet,,,,,,,,,,,,
+redstone-mainnet,,!offer:redstone,,mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/story/ramps.csv
+++ b/listings/specific-networks/story/ramps.csv
@@ -1,4 +1,3 @@
 slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
 alchemy-pay,,!offer:alchemy-pay,,,,,,,,
 halliday,,!offer:halliday,,,,,,,,
-transak,,!offer:transak,,,,,,,,

--- a/listings/specific-networks/story/ramps.csv
+++ b/listings/specific-networks/story/ramps.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
+alchemy-pay,,!offer:alchemy-pay,,,,,,,,
+halliday,,!offer:halliday,,,,,,,,
+transak,,!offer:transak,,,,,,,,


### PR DESCRIPTION
## Summary
This PR adds an initial **Story network infra-partners slice** across three categories using canonical `!offer:` linkage:
- `listings/specific-networks/story/apis.csv` (Alchemy, Ankr, QuickNode)
- `listings/specific-networks/story/oracles.csv` (Gelato, Pyth, RedStone)
- `listings/specific-networks/story/ramps.csv` (Alchemy Pay, Halliday, Transak)
- `listings/specific-networks/story/mainnet.png`

## Why this is safe
- Uses existing canonical offers from `references/offers/{apis,oracles,ramps}.csv` only (no new provider/offer entities).
- New rows are network-scoped and schema-aligned with canonical headers for each category.
- Slugs are sorted and row widths are consistent.
- Includes required `mainnet.png` for the new `story` network folder in the same PR.

## Sources used (official)
- Story RPC providers (Alchemy, QuickNode, Ankr):
  - https://docs.story.foundation/developers/infra-partners/rpc-provider.md
- Story oracle partners (Gelato, Pyth, RedStone):
  - https://docs.story.foundation/developers/infra-partners/oracles/gelato.md
  - https://docs.story.foundation/developers/infra-partners/oracles/pyth.md
  - https://docs.story.foundation/developers/infra-partners/oracles/redstone.md
- Story payment partners (Halliday, Transak, Alchemy Pay):
  - https://docs.story.foundation/developers/infra-partners/payment-solutions.md
- Story logo asset used for `mainnet.png`:
  - https://www.story.foundation/icon.png

## Candidate selection rationale
I considered multiple candidates and selected this one for best value-to-risk:
1. **Story bridges-only pack**: not selected because an open PR already covers Story bridges (`#1434`) and this would have been near-duplicate scope.
2. **Hyperliquid follow-up expansion**: not selected due concrete overlap risk with my open Hyperliquid PR (`#1442`) on the same network initiative.
3. **Another providers canonicalization batch**: not selected due near-identical intended repair to several of my still-open provider canonicalization PRs.
4. **Selected: Story infra-partners pack (apis/oracles/ramps)**: non-overlapping with my open PRs, official-source backed, coherent, and materially expands Story beyond bridges.

## Overlap check against my still-open PRs
Confirmed no concrete overlap with my open PR file scopes (no open USS Participator PR touches `listings/specific-networks/story/*`).
