### PR TITLE
feat(aurora): add official APIs, explorer, and oracle listings pack

### DIFF
--- a/listings/specific-networks/aurora/apis.csv
+++ b/listings/specific-networks/aurora/apis.csv
@@ -1,0 +1,5 @@
+slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+chainstack-mainnet-developer-recent-state,,!offer:chainstack-developer-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+infura-mainnet-core-recent-state,,!offer:infura-core-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+nownodes-mainnet-free-recent-state,,!offer:nownodes-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/aurora/apis.csv
+++ b/listings/specific-networks/aurora/apis.csv
@@ -1,5 +1,3 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
-chainstack-mainnet-developer-recent-state,,!offer:chainstack-developer-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
-infura-mainnet-core-recent-state,,!offer:infura-core-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 nownodes-mainnet-free-recent-state,,!offer:nownodes-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/aurora/explorers.csv
+++ b/listings/specific-networks/aurora/explorers.csv
@@ -1,1 +1,0 @@
-slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag

--- a/listings/specific-networks/aurora/explorers.csv
+++ b/listings/specific-networks/aurora/explorers.csv
@@ -1,2 +1,1 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.aurora.dev/)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/aurora/explorers.csv
+++ b/listings/specific-networks/aurora/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.aurora.dev/)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/aurora/oracles.csv
+++ b/listings/specific-networks/aurora/oracles.csv
@@ -1,4 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 dia-mainnet,,!offer:dia,,mainnet,,,,,,,,,,,,
 pyth-mainnet,,!offer:pyth,,mainnet,,,,,,,,,,,,
-redstone-mainnet,,!offer:redstone,,mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/aurora/oracles.csv
+++ b/listings/specific-networks/aurora/oracles.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+dia-mainnet,,!offer:dia,,mainnet,,,,,,,,,,,,
+pyth-mainnet,,!offer:pyth,,mainnet,,,,,,,,,,,,
+redstone-mainnet,,!offer:redstone,,mainnet,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Add an **official Aurora developer-tools expansion pack** by introducing three missing category files under `listings/specific-networks/aurora/`:
- `apis.csv` (4 official RPC providers from Aurora docs)
- `explorers.csv` (Aurora Blockscout explorer)
- `oracles.csv` (3 oracle integrations listed in Aurora docs)

## What changed
### `listings/specific-networks/aurora/apis.csv`
Added mainnet listings referencing existing canonical offers:
- `chainstack-mainnet-developer-recent-state` → `!offer:chainstack-developer-recent-state`
- `drpc-mainnet-public-recent-state` → `!offer:drpc-public-recent-state`
- `infura-mainnet-core-recent-state` → `!offer:infura-core-recent-state`
- `nownodes-mainnet-free-recent-state` → `!offer:nownodes-free-recent-state`

### `listings/specific-networks/aurora/explorers.csv`
- `blockscout-mainnet` → `!offer:blockscout`
- Added Aurora-specific explorer URL in action button: `https://explorer.aurora.dev/`

### `listings/specific-networks/aurora/oracles.csv`
Added mainnet listings referencing existing canonical offers:
- `dia-mainnet` → `!offer:dia`
- `pyth-mainnet` → `!offer:pyth`
- `redstone-mainnet` → `!offer:redstone`

## Why this is safe
- Uses only existing canonical offer slugs (no schema/model changes).
- Keeps canonical headers for each category and sorted slugs.
- Scoped to one coherent initiative (Aurora developer tools coverage).
- URLs used in touched rows/pages were checked reachable (HTTP 200).
- Diff is small/reviewable (3 new files, 11 added lines).

## Sources (official)
Aurora official docs pages:
- https://doc.aurora.dev/dev-tools/rpc-providers/chainstack/
- https://doc.aurora.dev/dev-tools/rpc-providers/drpc/
- https://doc.aurora.dev/dev-tools/rpc-providers/infura/
- https://doc.aurora.dev/dev-tools/rpc-providers/now-nodes/
- https://doc.aurora.dev/dev-tools/basics/block-explorer/
- https://doc.aurora.dev/dev-tools/oracles/dia/
- https://doc.aurora.dev/dev-tools/oracles/pyth/
- https://doc.aurora.dev/dev-tools/oracles/redstone/
- Aurora explorer endpoint referenced by docs: https://explorer.aurora.dev/

## Why this candidate
Aurora was underdeveloped (only `bridges.csv` present). This patch adds a coherent, official, developer-relevant tooling slice across APIs, explorers, and oracles with strong first-party sourcing and low risk.

## Why broader/alternative candidates were not chosen
- Broader Aurora expansion (wallets/indexers/services) was intentionally narrowed to the strongest clearly documented subset to keep evidence quality high and avoid weaker inference.
- Other sparse networks (e.g., single-category networks) were considered, but Aurora had the cleanest official per-tool documentation pages that map directly to existing canonical offers.

## Open-PR overlap check
I checked all still-open PRs authored by `USS-Participator` on `Chain-Love/chain-love` using live GitHub state before this PR.

Result: no open PR from me touches `listings/specific-networks/aurora/` or this specific APIs/explorers/oracles Aurora scope, so this PR is non-overlapping.
