### PR TITLE
feat(moonriver): add official connectivity and discovery listings pack

### DIFF
--- a/listings/specific-networks/moonriver/apis.csv
+++ b/listings/specific-networks/moonriver/apis.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+getblock-mainnet-free-recent-state,,!offer:getblock-free-recent-state,"[""[Website](https://getblock.io/nodes/movr/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+onfinality-mainnet-developer-full-archive,,!offer:onfinality-developer-full-archive,"[""[Website](https://onfinality.io/en/networks/moonriver)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/moonriver/explorers.csv
+++ b/listings/specific-networks/moonriver/explorers.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+moonscan-mainnet,,!offer:etherscan,"[""[Explore](https://moonriver.moonscan.io/)""]",mainnet,,,,,,,,,,,
+polkadot-js-mainnet,,!offer:polkadot-js,"[""[Explore](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonriver.moonbeam.network#/explorer)""]",mainnet,,,,,,,,,,,
+subscan-mainnet,,!offer:subscan,"[""[Explore](https://moonriver.subscan.io/)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/moonriver/sdks.csv
+++ b/listings/specific-networks/moonriver/sdks.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,programmingLanguage,tag,description,planType,planName,price,trial,starred,dependencies,latestKnownVersion,latestKnownReleaseDate,maintainer,license
+ethers-js,,!offer:ethers-js,,,,,,,,,,,,,,,

--- a/listings/specific-networks/moonriver/wallets.csv
+++ b/listings/specific-networks/moonriver/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds an official Moonriver listings expansion across four categories under `listings/specific-networks/moonriver/`:
- `apis.csv` (2 rows): GetBlock + OnFinality
- `explorers.csv` (3 rows): Moonscan, Polkadot.js, Subscan
- `wallets.csv` (1 row): MetaMask
- `sdks.csv` (1 row): Ethers.js

## Why this is safe
- Uses only canonical `!offer:<slug>` references to existing rows in `references/offers/{apis,explorers,wallets,sdks}.csv`
- Keeps one coherent theme (Moonriver official connectivity/discovery tooling)
- No schema changes, no reference-table edits, no provider edits
- Added files match canonical headers and keep slug ordering
- Existing `moonriver/mainnet.png` already satisfies chain-logo requirement (`chain=mainnet`)

## Sources used (official)
- Moonriver get started guide (network endpoints, block explorers, MetaMask mention, Ethers.js quick start):  
  https://docs.moonbeam.network/builders/get-started/networks/moonriver/
- Moonbeam API providers and endpoints (Moonbeam/Moonriver endpoint providers context):  
  https://docs.moonbeam.network/builders/get-started/endpoints/
- Moonbeam block explorers page (Moonriver explorers list):  
  https://docs.moonbeam.network/builders/get-started/explorers/
- GetBlock Moonriver node page:  
  https://getblock.io/nodes/movr/
- OnFinality Moonriver network page:  
  https://onfinality.io/en/networks/moonriver

## Why this was the best candidate
I considered several worthwhile paths (new-network packs, broader Moonriver expansion, provider-batch fixes) and selected this one because it had:
- strongest official-source coverage in a single docs family (Moonbeam docs)
- clear user value (Moonriver moves from bridges-only to multi-category discoverability)
- low risk with canonical offer references and no uncertain field inference

## Why broader/alternative candidates were not chosen
- Broader Moonriver API expansion (e.g., adding providers not explicitly confirmed for Moonriver) was narrowed to the strongest verified subset.
- New-network packs in this run had weaker immediate source clarity or higher overlap/ambiguity risk versus this official-doc-backed Moonriver slice.

## Overlap check against my still-open PRs
Checked all currently open PRs authored by `USS-Participator` in `Chain-Love/chain-love` using live GitHub state before editing.
- No open PR currently touches `listings/specific-networks/moonriver/*`
- This PR is non-overlapping in network/category/file scope with my still-open PRs.
