### PR TITLE
feat(celo/wallets): add official Celo-compatible wallet listings

### DIFF
--- a/listings/specific-networks/celo/wallets.csv
+++ b/listings/specific-networks/celo/wallets.csv
@@ -1,0 +1,9 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+1inch,,!offer:1inch,,,,,,,,,,,,,,,,,,,
+bridgewallet,,!offer:bridgewallet,,,,,,,,,,,,,,,,,,,
+metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
+okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,,
+safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,
+trustwallet,,!offer:trustwallet,,,,,,,,,,,,,,,,,,,
+zerion,,!offer:zerion,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
Added a new `listings/specific-networks/celo/wallets.csv` with 8 canonical `!offer:` wallet listings that are explicitly documented as Celo-compatible on official Celo docs:

- `1inch`
- `bridgewallet`
- `metamask`
- `okxwallet`
- `rabby`
- `safe-gnosis`
- `trustwallet`
- `zerion`

All rows use existing canonical offer slugs from `references/offers/wallets.csv`.

## Why this is safe
- No schema changes; uses the canonical wallets header already used across `listings/specific-networks/*/wallets.csv`.
- Only one new file in one network/category slice (`celo/wallets.csv`) for a focused, reviewable diff.
- Every row is `!offer`-linked to an existing canonical offer (no speculative direct-row fields).
- Validation passed:
  - `python3 /tmp/validate_csv.py listings/specific-networks/celo/wallets.csv`
  - slug ordering check (`sort -c`)
  - CSV row-width check (22 columns)
  - `!offer` slug existence check against `references/offers/wallets.csv`

## Sources used
Official Celo docs (first-party):
- https://docs.celo.org/home/wallets.md
- https://docs.celo.org/llms.txt (doc index, confirms canonical wallets page path)

## Why this was the best candidate
I evaluated several non-overlapping contribution directions and selected this one because it had:
- strong first-party evidence (single official page listing compatible wallets),
- high user value (fills a missing wallet category for Celo, which currently has analytics/bridges/mcpservers but no wallets),
- low risk and high reviewability (small, coherent, canonical-offer-only slice).

## Why broader/alternative candidates were not chosen
- **New bridge-network bootstrap packs**: deprioritized this run due high open-PR overlap/churn in bridge slices and weaker confidence on some chain-name alias mappings.
- **Provider metadata batches**: deprioritized because that area already has heavy concurrent open PR activity, increasing conflict risk.
- **Broader multi-network wallet sweep**: narrowed to one high-confidence network slice to keep source quality strong and review scope clean.

## Overlap check (still-open PRs)
Checked all still-open PRs authored by `USS-Creativity` in live GitHub state before selecting this task.
This PR does **not** overlap with any of them (no `listings/specific-networks/celo/wallets.csv` edits and no same network/category slice overlap).
