### PR TITLE
feat(rootstock): add official analytics + platform coverage from Rootstock dev-tools index

### DIFF
--- a/listings/specific-networks/rootstock/analytics.csv
+++ b/listings/specific-networks/rootstock/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/Rootstock)""]",mainnet,,,,,,,,,
+defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/Rootstock)""]",mainnet,,,,,,,,,
+defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/Rootstock)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/rootstock/platforms.csv
+++ b/listings/specific-networks/rootstock/platforms.csv
@@ -1,0 +1,5 @@
+slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
+thirdweb-growth,,!offer:thirdweb-growth,,,,,,,,,,
+thirdweb-pro,,!offer:thirdweb-pro,,,,,,,,,,
+thirdweb-scale,,!offer:thirdweb-scale,,,,,,,,,,
+thirdweb-starter,,!offer:thirdweb-starter,,,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds a focused Rootstock tooling slice in two new files:

- `listings/specific-networks/rootstock/analytics.csv`
  - `defillama-mainnet-api` → `!offer:defillama-api`
  - `defillama-mainnet-free` → `!offer:defillama-free`
  - `defillama-mainnet-pro` → `!offer:defillama-pro`
- `listings/specific-networks/rootstock/platforms.csv`
  - `thirdweb-growth` → `!offer:thirdweb-growth`
  - `thirdweb-pro` → `!offer:thirdweb-pro`
  - `thirdweb-scale` → `!offer:thirdweb-scale`
  - `thirdweb-starter` → `!offer:thirdweb-starter`

Theme in one sentence: **expand Rootstock’s official developer-tooling discoverability with canonical analytics + platform listings.**

## Why this is safe
- Uses only canonical `!offer:` references from `references/offers/{analytics,platforms}.csv` (no speculative new providers/offers).
- Slugs are sorted and schema headers match canonical category formats.
- No all-networks collisions for added slugs (`analytics` and `platforms` overlap check = none).
- Row-width checks pass (`analytics=14`, `platforms=13`).
- Local validation passes for both touched files (`python3 /tmp/validate_csv.py`).

## Sources used
Official Rootstock developer tooling index (first-party):
- https://dev.rootstock.io/dev-tools/
  - lists **DeFiLlama** under "data & analytics"
  - lists **Thirdweb** under "platforms"

(Analytics action buttons use the network-specific DeFiLlama page already aligned with existing repo pattern: `https://defillama.com/chain/Rootstock`.)

## Why this was the best candidate now
- Rootstock is materially underdeveloped on `upstream/main` (only bridges merged), while official docs provide clear, canonical tooling entries.
- This slice is substantial enough to be useful (7 rows across 2 categories) while staying highly reviewable and low-risk.
- It avoids high-conflict churn areas (provider metadata sweeps / overlap-heavy bridge slices).

## Why broader or alternative candidates were not chosen
- **Broader Rootstock expansion** (additional categories like faucets/security) was narrowed to keep this PR tightly sourced and avoid introducing direct rows tied to providers not yet canonicalized.
- **Bridge-heavy candidates** were deprioritized due current open-PR overlap pressure across many bridge network slices.
- **Provider CSV batches** were deprioritized due active concurrent churn/conflict risk in `references/providers/providers.csv`.

## Overlap check confirmation
Checked live open PR files before opening this PR.
No still-open PR (including my own) touches:
- `listings/specific-networks/rootstock/analytics.csv`
- `listings/specific-networks/rootstock/platforms.csv`
