### PR TITLE
feat(world-chain): expand official onboarding + account-abstraction/data starter listings

### DIFF
--- a/listings/specific-networks/world-chain/analytics.csv
+++ b/listings/specific-networks/world-chain/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+dune-mainnet-analyst,,!offer:dune-analyst,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,
+dune-mainnet-free,,!offer:dune-free,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,
+dune-mainnet-plus,,!offer:dune-plus,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/world-chain/platforms.csv
+++ b/listings/specific-networks/world-chain/platforms.csv
@@ -1,0 +1,5 @@
+slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
+thirdweb-growth,,!offer:thirdweb-growth,,,,,,,,,,
+thirdweb-pro,,!offer:thirdweb-pro,,,,,,,,,,
+thirdweb-scale,,!offer:thirdweb-scale,,,,,,,,,,
+thirdweb-starter,,!offer:thirdweb-starter,,,,,,,,,,

--- a/listings/specific-networks/world-chain/ramps.csv
+++ b/listings/specific-networks/world-chain/ramps.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
+moonpay,,!offer:moonpay,,,,,,,,
+ramp-network,,!offer:ramp-network,,,,,,,,

--- a/listings/specific-networks/world-chain/services.csv
+++ b/listings/specific-networks/world-chain/services.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+alchemy-gas-manager-free,,!offer:alchemy-gas-manager-free,,,,,,,,
+alchemy-gas-manager-pay-as-you-go,,!offer:alchemy-gas-manager-pay-as-you-go,,,,,,,,


### PR DESCRIPTION
## What changed
Added a coherent World Chain provider slice across **4 new category files** under `listings/specific-networks/world-chain/`:

- `analytics.csv` (3 rows): `dune-mainnet-analyst`, `dune-mainnet-free`, `dune-mainnet-plus`
- `ramps.csv` (2 rows): `moonpay`, `ramp-network`
- `services.csv` (2 rows): `alchemy-gas-manager-free`, `alchemy-gas-manager-pay-as-you-go`
- `platforms.csv` (4 rows): `thirdweb-growth`, `thirdweb-pro`, `thirdweb-scale`, `thirdweb-starter`

All rows use canonical `!offer:` linkage (no speculative direct rows).

## Why this is safe
- Uses only existing canonical offers in `references/offers/{analytics,ramps,services,platforms}.csv`
- Preserves canonical headers and row-widths for each category
- Slugs are sorted in each touched CSV
- Verified no all-networks duplication for added slugs in categories with `listings/all-networks/*`

Validation run:
- `python3 /tmp/validate_csv.py` on all 4 files (pass)
- slug-order checks (pass)
- csv-reader row-width checks (pass)
- `!offer` existence + all-networks collision checks (pass)

## Sources used
Official World docs pages:
- https://docs.world.org/world-chain/providers/data.md
- https://docs.world.org/world-chain/providers/onramps.md
- https://docs.world.org/world-chain/providers/paymasters.md
- https://docs.world.org/world-chain/providers/developer-tooling.md
- docs index: https://docs.world.org/llms.txt

## Why this was the best candidate this run
This candidate adds meaningful breadth to an already-started World Chain slice by covering **onboarding + account-abstraction + analytics** from first-party docs, while staying tightly scoped and easy to review.

## Why broader/alternative candidates were not chosen
- Broader World Chain expansion into already-open categories (`apis`, `explorers`, `oracles`) was skipped to avoid concrete overlap with an existing open PR on those exact files.
- Other network-wide expansions were deprioritized where live open-PR overlap/churn was higher for the same category slices.

## Overlap confirmation
Confirmed no concrete overlap with my still-open PRs: this PR only touches `world-chain/{analytics,platforms,ramps,services}.csv`, while my existing open World Chain PR touches `world-chain/{apis,explorers,oracles}.csv`.
