### PR TITLE
feat(fuse): add official explorer, wallet, and oracle listings

### DIFF
--- a/listings/specific-networks/fuse/explorers.csv
+++ b/listings/specific-networks/fuse/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.fuse.io/)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/fuse/oracles.csv
+++ b/listings/specific-networks/fuse/oracles.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+dia-mainnet,,!offer:dia,"[""[Feeds](https://docs.diadata.org/documentation/oracle-documentation/deployed-contracts#fuse)""]",mainnet,,,,,,,,,,,,
+supra-mainnet,,!offer:supra,"[""[Docs](https://supra.com/docs/overview/)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/fuse/oracles.csv
+++ b/listings/specific-networks/fuse/oracles.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
-dia-mainnet,,!offer:dia,"[""[Feeds](https://docs.diadata.org/documentation/oracle-documentation/deployed-contracts#fuse)""]",mainnet,,,,,,,,,,,,
-supra-mainnet,,!offer:supra,"[""[Docs](https://supra.com/docs/overview/)""]",mainnet,,,,,,,,,,,,
+dia-mainnet,,!offer:dia,"[""[Guide](https://www.diadata.org/docs/guides/chain-specific-guide/fuse)""]",mainnet,,,,,,,,,,,,
+supra-mainnet,,!offer:supra,"[""[Networks](https://docs.supra.com/oracles/data-feeds/pull-oracle/networks)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/fuse/wallets.csv
+++ b/listings/specific-networks/fuse/wallets.csv
@@ -1,0 +1,6 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+alphawallet,,!offer:alphawallet,,,,,,,,,,,,,,,,,,,
+frontier,,!offer:frontier,,,,,,,,,,,,,,,,,,,
+metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,,
+safepal,,!offer:safepal,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
This PR adds a **Fuse ecosystem discovery pack** for categories that were missing under `listings/specific-networks/fuse/`.

### What changed
- Added `listings/specific-networks/fuse/explorers.csv`
  - `blockscout-mainnet` → `!offer:blockscout` (Fuse Explorer)
- Added `listings/specific-networks/fuse/wallets.csv`
  - `alphawallet`, `frontier`, `metamask`, `rabby`, `safepal`
- Added `listings/specific-networks/fuse/oracles.csv`
  - `dia-mainnet` → `!offer:dia`
  - `supra-mainnet` → `!offer:supra`

## Why this is safe
- Uses canonical `!offer:<slug>` linkage only (no speculative provider/profile edits).
- All rows are sourced from official Fuse docs pages for Fuse ecosystem components.
- Scope is one coherent initiative (Fuse discovery coverage) with no unrelated edits.
- CSV sanity checks passed:
  - row-width consistency for all touched files
  - slug ordering checks for all touched files

## Sources used (official)
- Fuse Explorer page: https://docs.fuse.io/basics/ecosystem/fuse-explorer
- Fuse Wallets page: https://docs.fuse.io/basics/ecosystem/wallets-on-fuse
- Fuse Oracles page: https://docs.fuse.io/basics/ecosystem/oracles

## Why this was the best candidate
- `fuse/` had only `bridges.csv`, so adding explorer + wallets + oracles materially improves usability and discovery for a clearly underdeveloped network slice.
- Strong official-source coverage exists for these exact categories, enabling high-confidence additions without schema risk.

## Why broader/alternative candidates were not chosen
- I considered broader Moonriver/Aurora expansions, but they had concrete overlap with existing open PRs by other contributors.
- I considered adding Fuse API rows too, but narrowed scope to the strongest subset with the cleanest source-to-offer mapping and lowest ambiguity.

## Overlap check
Confirmed this PR does **not** overlap with any still-open PRs authored by `USS-Creativity` (no open USS-Creativity PR touches `listings/specific-networks/fuse/*`).
