### PR TITLE
feat(bitcoin-cash): add official wallets + explorer baseline

### DIFF
--- a/listings/specific-networks/bitcoin-cash/explorers.csv
+++ b/listings/specific-networks/bitcoin-cash/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockchair-mainnet,,!offer:blockchair,"[""[Explore](https://blockchair.com/bitcoin-cash)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/bitcoin-cash/wallets.csv
+++ b/listings/specific-networks/bitcoin-cash/wallets.csv
@@ -1,0 +1,11 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+bitcoin-com-wallet,,!offer:bitcoin-com-wallet,,,,,,,,,,,,,,,,,,,
+coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
+coinomi-wallet,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,
+edge-wallet,,!offer:edge-wallet,,,,,,,,,,,,,,,,,,,
+exodus,,!offer:exodus,,,,,,,,,,,,,,,,,,,
+gem-wallet,,!offer:gem-wallet,,,,,,,,,,,,,,,,,,,
+guarda,,!offer:guarda,,,,,,,,,,,,,,,,,,,
+ledger,,!offer:ledger,,,,,,,,,,,,,,,,,,,
+trezor,,!offer:trezor,,,,,,,,,,,,,,,,,,,
+unstoppable,,!offer:unstoppable,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds a focused **Bitcoin Cash discoverability slice** by introducing two missing listing categories under `listings/specific-networks/bitcoin-cash/`:

1. `wallets.csv` (10 canonical `!offer:` rows)
   - `bitcoin-com-wallet`
   - `coin-wallet`
   - `coinomi-wallet`
   - `edge-wallet`
   - `exodus`
   - `gem-wallet`
   - `guarda`
   - `ledger`
   - `trezor`
   - `unstoppable`

2. `explorers.csv` (1 canonical `!offer:` row)
   - `blockchair-mainnet`

## Why this is safe
- Only adds new listing files for an existing network folder (`bitcoin-cash`); no schema/header changes.
- Uses existing canonical offers via `!offer:<slug>` (no new providers/offers introduced).
- Every added wallet/explorer comes from the official Bitcoin Cash ecosystem page.
- Validation passed:
  - `python3 /tmp/validate_csv.py listings/specific-networks/bitcoin-cash/wallets.csv listings/specific-networks/bitcoin-cash/explorers.csv`
  - CSV row-width checks
  - `!offer` linkage checks against `references/offers/{wallets,explorers}.csv`

## Sources used (official)
- https://bitcoincash.org/  
  - Wallets section
  - Explorers section

## Why this was the best candidate this run
- High user value: `bitcoin-cash` previously had APIs/analytics/MCP data but lacked wallet and explorer discoverability.
- Strong evidence quality: direct first-party source with explicit wallet and explorer lists.
- Reviewable scope: one coherent theme, two files, low blast radius.

## Why broader/alternative candidates were not chosen
- **Katana / Moonriver / Taiko expansions**: open PR overlap/churn was already high on those network slices this cycle.
- **Zora expansion**: currently weaker/less explicit official network-tooling evidence than Bitcoin Cash for a safe canonical listing batch.
- **Broader Bitcoin Cash expansion (services/nodes)**: intentionally narrowed to the strongest canonical subset (wallets + explorer) for clear evidence and fast reviewability.

## Overlap check
Confirmed against live GitHub open PR state (including all still-open PRs authored by `USS-Creativity`): no open PR touches these target paths:
- `listings/specific-networks/bitcoin-cash/wallets.csv`
- `listings/specific-networks/bitcoin-cash/explorers.csv`
