### PR TITLE
feat(zora): add official API, explorer, and wallet access baseline

### DIFF
--- a/listings/specific-networks/zora/apis.csv
+++ b/listings/specific-networks/zora/apis.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/zora/explorers.csv
+++ b/listings/specific-networks/zora/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.zora.energy/)"",""[Docs](https://explorer.zora.energy/api-docs)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/zora/explorers.csv
+++ b/listings/specific-networks/zora/explorers.csv
@@ -1,1 +1,0 @@
-slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag

--- a/listings/specific-networks/zora/explorers.csv
+++ b/listings/specific-networks/zora/explorers.csv
@@ -1,2 +1,1 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.zora.energy/)"",""[Docs](https://explorer.zora.energy/api-docs)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/zora/wallets.csv
+++ b/listings/specific-networks/zora/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds an official **Zora network access starter slice** across three categories:

- `listings/specific-networks/zora/apis.csv`
  - `drpc-mainnet-public-recent-state` → `!offer:drpc-public-recent-state`
  - `quicknode-mainnet-build-recent-state` → `!offer:quicknode-build-recent-state`
- `listings/specific-networks/zora/explorers.csv`
  - `blockscout-mainnet` → `!offer:blockscout` with Zora explorer links
- `listings/specific-networks/zora/wallets.csv`
  - `metamask` → `!offer:metamask`

Theme in one sentence: **fill the Zora official access baseline (RPC, explorer, wallet) using first-party docs and canonical offers.**

## Why this is safe
- Uses canonical `!offer:` linkage only (no schema changes, no provider mutations).
- Touches one network (`zora`) and three closely related onboarding categories.
- New files follow canonical headers and slug ordering.
- Validation performed:
  - `python3 /tmp/validate_csv.py` on all touched files (pass)
  - slug ordering checks (pass)
  - csv-reader row-width checks (apis=29, explorers=16, wallets=22; pass)
  - `!offer` linkage checks vs canonical offers (pass)

## Sources used (official)
- https://nft-docs.zora.co/llms.txt
- https://nft-docs.zora.co/zora-network/api-access
- https://nft-docs.zora.co/zora-network/network
- https://nft-docs.zora.co/zora-network/metamask

## Why this was the best candidate this run
- Strong first-party evidence for all added entities.
- Material value: Zora moved from bridges-only to a usable access baseline (API + explorer + wallet).
- Coherent, reviewable scope with low blast radius.

## Why broader/alternative candidates were not chosen
- **Kaia expansion**: concrete overlap risk with open PR `#1529` (Kaia explorers/oracles/wallets already proposed) and own open `#1626` on Kaia APIs.
- **Katana expansion**: concrete overlap with open PR `#1471` covering Katana across multiple categories.
- **Moonriver expansion**: concrete overlap with open PR `#1535` and additional Moonriver open file churn.

## Overlap confirmation
Checked still-open PRs before implementation (live GitHub state):
- No still-open PR (including my own) touches `listings/specific-networks/zora/apis.csv`, `zora/explorers.csv`, or `zora/wallets.csv`.
