### PR TITLE
feat(merlin): expand official wallet coverage with Bitget + Safe

### DIFF
--- a/listings/specific-networks/merlin/wallets.csv
+++ b/listings/specific-networks/merlin/wallets.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+bitget-wallet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
 okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
Expanded `listings/specific-networks/merlin/wallets.csv` by adding two officially documented Merlin-compatible wallets:
- `bitget-wallet` → `!offer:bitget-wallet`
- `safe-gnosis` → `!offer:safe-gnosis`

## Why this is safe
- Uses existing canonical wallet offers already present in `references/offers/wallets.csv`.
- Keeps schema/header unchanged.
- Preserves slug ordering and CSV row width.
- Scope is a single coherent initiative: improve Merlin wallet compatibility coverage from first-party docs.

## Sources used (official)
1. Merlin docs — BTC wallet connection (lists supported BTC wallets including Bitget and OKX):
   - https://docs.merlinchain.io/merlin-docs/developers/builder-guides/developer-tools/wallet/connecting-to-merlin-via-btc-wallet
2. Merlin docs — Multi-sig wallets (states Safe Wallet is deployed on Merlin):
   - https://docs.merlinchain.io/merlin-docs/developers/builder-guides/developer-tools/wallet/multi-sig-wallets

## Why this was the best candidate
- High-confidence, first-party documentation with explicit wallet names.
- Non-overlapping with open Merlin PRs on `apis.csv`/`analytics.csv` and non-overlapping with broad stale storage sweeps.
- Direct user value: improves Merlin wallet discoverability with concrete, official compatibility entries.

## Why broader/alternative candidates were not chosen
- **Moonriver/Telos/Katana broad ecosystem packs**: open PR overlap in the same network/category slices (or near-identical scope) made collision risk high.
- **Merlin analytics expansion**: overlaps with my own still-open PR `#1576` category slice (`analytics.csv`).
- **Adding non-canonical new wallet providers (e.g., UniSat/Xverse)**: would require new provider + offer onboarding (including logos), increasing risk for this run.

## Open-PR overlap check
Checked live open PRs and confirmed this PR does **not** overlap my still-open PRs by file/category/entity:
- No open PR currently modifies `listings/specific-networks/merlin/wallets.csv`.
- My open Merlin PR `#1576` targets `apis.csv` and `analytics.csv` only.
