### PR TITLE
feat(kaspa): expand official wallet matrix with five first-party listed options

### DIFF
--- a/listings/specific-networks/kaspa/wallets.csv
+++ b/listings/specific-networks/kaspa/wallets.csv
@@ -1,4 +1,9 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
+ellipal,,!offer:ellipal,,,,,,,,,,,,,,,,,,,
+ledger,,!offer:ledger,,,,,,,,,,,,,,,,,,,
+okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+onekey,,!offer:onekey,,,,,,,,,,,,,,,,,,,
 safepal,,!offer:safepal,,,,,,,,,,,,,,,,,,,
+tangem,,!offer:tangem,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
Expanded `listings/specific-networks/kaspa/wallets.csv` by adding 5 officially listed wallet options:
- `ellipal`
- `ledger`
- `okxwallet`
- `onekey`
- `tangem`

All rows use existing canonical `!offer:` references; no schema/header changes.

## Why this is safe
- Uses existing canonical wallet offers from `references/offers/wallets.csv` only.
- Keeps CSV schema unchanged and preserves slug ordering.
- Scoped to one coherent file/category in one network (`kaspa/wallets`).
- Local validation passed (`python3 /tmp/validate_csv.py` + row-width sanity check).

## Sources used (official-first)
- https://kaspa.org/ (official Kaspa site wallet section listing OneKey, Tangem, OKX Web3, Ledger, Ellipal among supported options)
- https://kaspa.org/page-sitemap.xml (official sitemap confirming canonical page surface)

## Why this was the best candidate now
Kaspa currently has very thin wallet coverage in this repo (3 rows). This patch materially improves practical wallet discoverability with high-confidence, first-party evidence while staying reviewable and low-risk.

## Why broader/alternative candidates were not chosen
- **Kaspa APIs / analytics / storages**: concrete overlap with still-open PRs in those exact categories.
- **Moonriver / Telos continuations**: concrete open-PR overlap on same network/category slices.
- **Kaspa explorers add-on in this PR**: intentionally narrowed out to keep this iteration on the strongest unambiguous official wallet evidence.

## Open-PR overlap confirmation
Checked live open PR state: no still-open PR (including my own) touches `listings/specific-networks/kaspa/wallets.csv`.
