### PR TITLE
feat(hyperliquid): add official HyperCore analytics coverage

### DIFF
--- a/listings/specific-networks/hyperliquid/analytics.csv
+++ b/listings/specific-networks/hyperliquid/analytics.csv
@@ -1,0 +1,5 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://app.artemis.xyz/project/hyperliquid)""]",mainnet,,,,,,,,,
+defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/perps/chains/hyperliquid)""]",mainnet,,,,,,,,,
+dune-mainnet-free,,!offer:dune-free,"[""[Dashboard](https://dune.com/mogie/hyperliquid-flows)""]",mainnet,,,,,,,,,
+laevitas-mainnet-free,,!offer:laevitas-free,"[""[Dashboard](https://app.laevitas.ch/exchanges/perpswaps/HYPERLIQUID/screener)""]",mainnet,,,,,,,,,


### PR DESCRIPTION
## What changed
- Added `listings/specific-networks/hyperliquid/analytics.csv` with four official HyperCore analytics listings:
  - `artemis-mainnet` → `!offer:artemis`
  - `defillama-mainnet-free` → `!offer:defillama-free`
  - `dune-mainnet-free` → `!offer:dune-free`
  - `laevitas-mainnet-free` → `!offer:laevitas-free`
- Added network-specific dashboard URLs from Hyperliquid’s official HyperCore tools page.

## Why this is safe
- Uses existing canonical offers only (`!offer:` references), no schema changes.
- Keeps canonical analytics header and `mainnet` chain value already supported by `listings/specific-networks/hyperliquid/mainnet.png`.
- Slugs are unique and alphabetically ordered.

## Sources used
- Hyperliquid docs (official): https://hyperliquid.gitbook.io/hyperliquid-docs/builder-tools/hypercore-tools
  - Analytics section (Artemis, DefiLlama, Dune dashboards, Laevitas).

## Why this was the best candidate
- Hyperliquid had no `analytics.csv` despite official HyperCore docs listing multiple analytics options.
- This closes a clear discoverability gap with first-party evidence and existing canonical offers, so value/risk is strong.

## Why broader/alternative candidates were not chosen
- Broader Hyperliquid expansion (explorers/indexing/custody) currently lacks matching canonical offers for many official tools, which would require larger provider/offer creation and increase review risk.
- Other searched candidates (Core/X Layer/Starknet ramp expansion variants) either had weaker canonical linkage or required wider cross-file provider onboarding to stay evidence-safe.

## Non-overlap check with my still-open PRs
- Confirmed no concrete overlap with my open PR scopes: this PR only adds `listings/specific-networks/hyperliquid/analytics.csv`.
- My still-open Hyperliquid PR (`#1444`) targets different slices (`apis`, `bridges`, `wallets`) and does not touch analytics.
