### PR TITLE
feat(litecoin): add canonical explorer baseline with Blockchair, BlockCypher, and OKLink

### DIFF
--- a/listings/specific-networks/litecoin/explorers.csv
+++ b/listings/specific-networks/litecoin/explorers.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockchair-mainnet,,!offer:blockchair,"[""[Explore](https://blockchair.com/litecoin)""]",mainnet,,,,,,,,,,,
+blockcypher-mainnet,,!offer:blockcypher,"[""[Explore](https://live.blockcypher.com/ltc/)""]",mainnet,,,,,,,,,,,
+oklink-mainnet,,!offer:oklink,"[""[Explore](https://www.oklink.com/litecoin)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds a new `listings/specific-networks/litecoin/explorers.csv` file with three canonical explorer listings for Litecoin mainnet:
- `blockchair-mainnet` (`!offer:blockchair`)
- `blockcypher-mainnet` (`!offer:blockcypher`)
- `oklink-mainnet` (`!offer:oklink`)

## Why it is safe
- Uses existing canonical `!offer:` references (no new provider rows, no new offer rows, no schema changes).
- Adds one coherent missing slice (Litecoin explorers) without touching unrelated areas.
- Keeps canonical CSV header/order and slug ordering.

## Sources used
Official sources consulted for Litecoin explorer support:
- Blockchair Litecoin explorer: https://blockchair.com/litecoin
- BlockCypher developer docs (explicit Litecoin support) + live explorer URL pattern:
  - https://www.blockcypher.com/dev/
  - https://live.blockcypher.com/ltc/
- OKLink Litecoin explorer: https://www.oklink.com/litecoin

## Why this was the best candidate
- `litecoin` had no `explorers.csv` at all on `main`; adding this file materially improves discoverability for a top network with a compact, reviewable patch.
- This initiative is narrowly scoped but complete (introduces the missing category with multiple canonical entries).
- Lowest value-to-risk among candidates: strong official sources + existing canonical offers + minimal blast radius.

## Why broader/alternative candidates were not chosen
- **Starknet security/faucet expansion:** valid but lower net value in this run (smaller incremental gain and/or required new canonical objects).
- **Core explorer/faucet expansion:** required introducing new provider/offer canonical rows (broader cross-file change than needed for this cycle).
- **Tezos explorer expansion:** promising, but would require a larger provider/offers bootstrap (logos + canonical linkage) to stay standards-compliant.

## Non-overlap confirmation
I checked still-open PRs from `USS-Creativity` against live GitHub state. This PR does **not** overlap with open PR scopes by network/category/entities/rows; none of my open PRs add or modify `listings/specific-networks/litecoin/explorers.csv` or these explorer slugs.
