### PR TITLE
feat(moonbeam): add official SDK, service, and on-ramp listings

### DIFF
--- a/listings/specific-networks/moonbeam/ramps.csv
+++ b/listings/specific-networks/moonbeam/ramps.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
+transak,,!offer:transak,"[""[Buy GLMR](https://transak.com/buy/glmr)""]",,,,,,,

--- a/listings/specific-networks/moonbeam/ramps.csv
+++ b/listings/specific-networks/moonbeam/ramps.csv
@@ -1,2 +1,2 @@
 slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
-transak,,!offer:transak,"[""[Buy GLMR](https://transak.com/buy/glmr)""]",,,,,,,
+transak,,!offer:transak,,,,,,,,

--- a/listings/specific-networks/moonbeam/sdks.csv
+++ b/listings/specific-networks/moonbeam/sdks.csv
@@ -1,0 +1,5 @@
+slug,provider,offer,actionButtons,toolType,programmingLanguage,tag,description,planType,planName,price,trial,starred,dependencies,latestKnownVersion,latestKnownReleaseDate,maintainer,license
+ethers-js,,!offer:ethers-js,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/libraries/ethersjs/)""]",,,,,,,,,,,,,,
+foundry,,!offer:foundry,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/dev-env/foundry/)""]",,,,,,,,,,,,,,
+hardhat,,!offer:hardhat,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/dev-env/hardhat/)""]",,,,,,,,,,,,,,
+web3-py,,!offer:web3-py,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/libraries/web3py/)""]",,,,,,,,,,,,,,

--- a/listings/specific-networks/moonbeam/sdks.csv
+++ b/listings/specific-networks/moonbeam/sdks.csv
@@ -1,5 +1,5 @@
 slug,provider,offer,actionButtons,toolType,programmingLanguage,tag,description,planType,planName,price,trial,starred,dependencies,latestKnownVersion,latestKnownReleaseDate,maintainer,license
-ethers-js,,!offer:ethers-js,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/libraries/ethersjs/)""]",,,,,,,,,,,,,,
-foundry,,!offer:foundry,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/dev-env/foundry/)""]",,,,,,,,,,,,,,
-hardhat,,!offer:hardhat,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/dev-env/hardhat/)""]",,,,,,,,,,,,,,
-web3-py,,!offer:web3-py,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/libraries/web3py/)""]",,,,,,,,,,,,,,
+ethers-js,,!offer:ethers-js,,,,,,,,,,,,,,,
+foundry,,!offer:foundry,,,,,,,,,,,,,,,
+hardhat,,!offer:hardhat,,,,,,,,,,,,,,,
+web3-py,,!offer:web3-py,,,,,,,,,,,,,,,

--- a/listings/specific-networks/moonbeam/services.csv
+++ b/listings/specific-networks/moonbeam/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+remix,,!offer:remix,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/dev-env/remix/)""]",,,,,,,

--- a/listings/specific-networks/moonbeam/services.csv
+++ b/listings/specific-networks/moonbeam/services.csv
@@ -1,2 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
-remix,,!offer:remix,"[""[Docs](https://docs.moonbeam.network/builders/ethereum/dev-env/remix/)""]",,,,,,,
+remix,,!offer:remix,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds a focused **Moonbeam onboarding + developer-tooling slice** across three previously missing categories:

- `listings/specific-networks/moonbeam/sdks.csv`
  - `ethers-js`
  - `foundry`
  - `hardhat`
  - `web3-py`
- `listings/specific-networks/moonbeam/services.csv`
  - `remix`
- `listings/specific-networks/moonbeam/ramps.csv`
  - `transak`

All new rows use canonical `!offer:` linkage and preserve existing CSV formatting conventions.

## Why this is safe
- Only one coherent initiative (Moonbeam-specific tooling/onramp expansion).
- Only additive rows/files; no schema changes.
- Uses existing canonical offers from `references/offers/{sdks,services,ramps}.csv`.
- No provider-name or offer-slug inventions.
- New CSVs pass row-width and slug-order sanity checks.

## Sources used (official, first-party)
- Moonbeam Docs — Ethers.js library guide:  
  https://docs.moonbeam.network/builders/ethereum/libraries/ethersjs/
- Moonbeam Docs — Web3.py library guide:  
  https://docs.moonbeam.network/builders/ethereum/libraries/web3py/
- Moonbeam Docs — Hardhat guide:  
  https://docs.moonbeam.network/builders/ethereum/dev-env/hardhat/
- Moonbeam Docs — Foundry guide:  
  https://docs.moonbeam.network/builders/ethereum/dev-env/foundry/
- Moonbeam Docs — Remix guide:  
  https://docs.moonbeam.network/builders/ethereum/dev-env/remix/
- Moonbeam Docs — Fiat on-ramp guide (Transak/GLMR):  
  https://docs.moonbeam.network/tokens/connect/on-ramps/

## Why this was the best candidate now
I prioritized a high-confidence slice with strong official documentation and clear user value: Moonbeam had no `sdks`, `services`, or `ramps` listings on `main`, while its docs provide explicit first-party support for these tools.

## Why broader/alternative candidates were not chosen
- Broader Moonbeam expansion (more categories/providers) would require adding net-new canonical offers/providers in this run, increasing review risk.
- Other promising networks had active open PR overlap in the same category slices, increasing duplicate-work risk.
- This narrowed subset is the strongest coherent, non-overlapping, evidence-backed increment for this cycle.

## Open-PR overlap check
Confirmed against still-open USS Creativity PRs and global open PR file paths:
- No overlap on `listings/specific-networks/moonbeam/{sdks.csv,services.csv,ramps.csv}`.
- This PR is disjoint from my currently open Moonbeam-absent PR set.
