### PR TITLE
feat(starknet): add official security auditor listings baseline

### DIFF
--- a/listings/specific-networks/starknet/security.csv
+++ b/listings/specific-networks/starknet/security.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,tag,description,planType,planName,price,trial,starred,toolType,deliveryType,executionEnvironment,coverage,compliance
+consensys-diligence-builder,,!offer:consensys-diligence-builder,,,,,,,,,,,,,
+openzeppelin-audits,,!offer:openzeppelin-audits,,,,,,,,,,,,,


### PR DESCRIPTION
## What changed
This PR adds a missing Starknet `security` category file and seeds it with officially documented auditors from Starknet’s integrations page:

- `listings/specific-networks/starknet/security.csv` (new)
  - `consensys-diligence-builder` (`!offer:consensys-diligence-builder`)
  - `openzeppelin-audits` (`!offer:openzeppelin-audits`)

## Why this is safe
- Uses existing canonical `!offer:` slugs from `references/offers/security.csv` (no new providers/offers introduced).
- No schema/header changes; canonical security listing header used.
- Slugs are alphabetically ordered.
- Validation passed:
  - `python3 /tmp/validate_csv.py listings/specific-networks/starknet/security.csv`
  - row-width sanity check (16 columns)
  - `!offer` linkage check against `references/offers/security.csv`

## Sources used (official)
- Starknet developer integrations (Security → Auditors includes ConsenSys and Open Zeppelin):
  - https://docs.starknet.io/learn/cheatsheets/integrations
- Starknet docs source mirror:
  - https://raw.githubusercontent.com/starknet-io/starknet-docs/main/learn/cheatsheets/integrations.mdx

## Why this was the best candidate this run
- It closes a concrete Starknet category gap (`security.csv` missing) with high-confidence first-party evidence.
- It is coherent, reviewable, and materially improves Starknet discoverability in one slice.
- It avoids fragile cross-file migrations and avoids introducing speculative new entities.

## Why broader/alternative candidates were not chosen
- Broader Starknet expansion (faucets/explorers/ramps) would require introducing new canonical offers/providers not yet present, increasing linkage risk this run.
- X Layer platform expansion was narrowed out because key candidates (`particle`, `privy`) are already present in `listings/all-networks/platforms.csv`, and duplicating them in network-specific listings would violate placement guardrails.
- Ronin service/faucet broadening required new entity onboarding with weaker immediate canonical mapping than this Starknet security subset.

## Open-PR overlap check (live)
Confirmed no concrete overlap with still-open PRs authored by `USS-Creativity`:
- no open PR touches `listings/specific-networks/starknet/security.csv`
- no same network/category slice overlap with open Starknet PRs (`apis`, `wallets`, `bridges`, `oracles`, `analytics` are separate)

Discussion #41 alignment: improves database completeness with source-backed, user-discoverable integrations in an underfilled network slice.
