### PR TITLE
feat(boba): bootstrap official testnet faucet baseline from Boba docs

### DIFF
--- a/listings/specific-networks/boba/faucets.csv
+++ b/listings/specific-networks/boba/faucets.csv
@@ -1,0 +1,5 @@
+slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,requiredMainnetBalance,price,dripLimitAmount,dripLimitPeriod,additionalNotes,starred,tag
+alchemy-faucet-testnet,,!offer:alchemy-faucet,"[""[Faucet](https://www.alchemy.com/faucets/ethereum-sepolia)""]",testnet,,,,,,,,,
+infura-faucet-testnet,,!offer:infura-faucet,"[""[Faucet](https://www.infura.io/faucet/sepolia)""]",testnet,,,,,,,,,
+pk910-faucet-testnet,,!offer:pk910-faucet,"[""[Faucet](https://sepolia-faucet.pk910.de/)""]",testnet,,,,,,,,,
+quicknode-faucet-testnet,,!offer:quicknode-faucet,"[""[Faucet](https://faucet.quicknode.com/drip)""]",testnet,,,,,,,,,

--- a/listings/specific-networks/boba/faucets.csv
+++ b/listings/specific-networks/boba/faucets.csv
@@ -1,5 +1,5 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,requiredMainnetBalance,price,dripLimitAmount,dripLimitPeriod,additionalNotes,starred,tag
-alchemy-faucet-testnet,,!offer:alchemy-faucet,"[""[Faucet](https://www.alchemy.com/faucets/ethereum-sepolia)""]",testnet,,,,,,,,,
-infura-faucet-testnet,,!offer:infura-faucet,"[""[Faucet](https://www.infura.io/faucet/sepolia)""]",testnet,,,,,,,,,
-pk910-faucet-testnet,,!offer:pk910-faucet,"[""[Faucet](https://sepolia-faucet.pk910.de/)""]",testnet,,,,,,,,,
-quicknode-faucet-testnet,,!offer:quicknode-faucet,"[""[Faucet](https://faucet.quicknode.com/drip)""]",testnet,,,,,,,,,
+alchemy-faucet-testnet,,!offer:alchemy-faucet,"[""[Faucet](https://www.alchemy.com/faucets/ethereum-sepolia)""]",testnet,,,,,,,"[""Boba docs list this faucet for Sepolia ETH; bridge funds to Boba Sepolia via Boba Hub.""]",,
+infura-faucet-testnet,,!offer:infura-faucet,"[""[Faucet](https://www.infura.io/faucet/sepolia)""]",testnet,,,,,,,"[""Boba docs list this faucet for Sepolia ETH; bridge funds to Boba Sepolia via Boba Hub.""]",,
+pk910-faucet-testnet,,!offer:pk910-faucet,"[""[Faucet](https://sepolia-faucet.pk910.de/)""]",testnet,,,,,,,"[""Boba docs list this faucet for Sepolia ETH; bridge funds to Boba Sepolia via Boba Hub.""]",,
+quicknode-faucet-testnet,,!offer:quicknode-faucet,"[""[Faucet](https://faucet.quicknode.com/drip)""]",testnet,,,,,,,"[""Boba docs list this faucet for Sepolia ETH; bridge funds to Boba Sepolia via Boba Hub.""]",,


### PR DESCRIPTION
## What changed
- Added a new file: `listings/specific-networks/boba/faucets.csv`.
- Added 4 canonical `!offer:`-linked faucet rows for Boba testnet onboarding:
  - `alchemy-faucet-testnet`
  - `infura-faucet-testnet`
  - `pk910-faucet-testnet`
  - `quicknode-faucet-testnet`
- Kept scope intentionally single-category and network-specific for clean reviewability.

## Why this is safe
- Uses existing canonical faucet offers only (`alchemy-faucet`, `infura-faucet`, `pk910-faucet`, `quicknode-faucet`) — no new provider or offer entities introduced.
- `chain` is set to `testnet`, which is already supported by existing `listings/specific-networks/boba/testnet.png`.
- Validation checks passed:
  - `python3 /tmp/validate_csv.py listings/specific-networks/boba/faucets.csv`
  - slug ordering check
  - CSV row-width check (14 columns)
  - `!offer` linkage check against `references/offers/faucets.csv`
  - chain-logo coverage check for `boba/` folder (`mainnet`, `testnet`)

## Sources used (official)
- Boba docs — Testnet Faucets: https://docs.boba.network/faucets

## Why this was the best candidate
- `boba` had no faucet listing file at all, so adding a first official faucet baseline materially improves onboarding discoverability for that network.
- Evidence is first-party and explicit (Boba docs enumerate faucet options).
- Low-risk, high-signal improvement with clear user value and minimal schema risk.

## Why broader/alternative candidates were not chosen
- **Broader Boba faucet expansion (all faucets listed on the docs page)** was narrowed because several listed faucets do not yet have canonical offers/providers in this repository (`L2Faucet`, `Boba ETH Testnet Faucet`, `EthFaucet.com`). I avoided speculative provider onboarding in this run.
- **Scroll ecosystem expansion** was deprioritized this run because the linked ecosystem endpoint from docs is currently not a stable canonical data source for row-level provider extraction.
- **Katana expansion** was deprioritized due weaker immediate category-aligned extraction compared to Boba’s explicit faucet matrix.

## Overlap check
- Confirmed no open PR currently touches `listings/specific-networks/boba/faucets.csv` (live search).
- Confirmed no open PR currently touches `references/offers/faucets.csv` in this run.
- Therefore this PR does not concretely overlap with my still-open PRs.
