### PR TITLE
chore(meta): clarify offer field description in column metadata

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -58,7 +58,7 @@
     "key": "offer",
     "label": "Offer",
     "icon": "lucide:Unplug",
-    "description": "Service offer",
+    "description": "Optional custom offer name; leave blank to use auto-generated Chain.Love slug conventions.",
     "filter": null,
     "sorting": null,
     "pinning": "left",


### PR DESCRIPTION
Updates the offer column tooltip text in meta columns to clearly state that this is an optional custom offer name. If left blank, the slug is generated automatically using Chain.Love conventions.