### PR TITLE
chore(ci): use GET for link-checker

### DIFF
--- a/.github/workflows/link-check-analysis.yaml
+++ b/.github/workflows/link-check-analysis.yaml
@@ -144,6 +144,7 @@ jobs:
           failIfEmpty: false
           args: >
             --extensions csv
+            --method GET
             --accept 200,204,400,401,403,405,429
             --timeout 5
             --no-progress


### PR DESCRIPTION
Closes #1718 (maybe)

It seems that a lot of sites timeout on HEAD requests and accept GET ones.