### PR TITLE
Add Chainlink Data Feeds oracle links

### DIFF
--- a/listings/specific-networks/bob/oracles.csv
+++ b/listings/specific-networks/bob/oracles.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 acurast-mainnet,,!offer:acurast,,mainnet,,,,,,,,,,,,
 api3-mainnet,,!offer:api3,"[""[Website](https://market.api3.org/bob)""]",mainnet,,,,,,,,,,,,
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=bob-mainnet)""]",mainnet,,,,,,,,,,,,
 dia-mainnet,,!offer:dia,"[""[Docs](https://www.diadata.org/docs/guides/chain-specific-guide/bob-build-on-bitcoin)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/botanix/oracles.csv
+++ b/listings/specific-networks/botanix/oracles.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=botanix-mainnet)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/celo/oracles.csv
+++ b/listings/specific-networks/celo/oracles.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 band-mainnet,,!offer:band,,mainnet,,,,,,,,,,,,
-chainlink-mainnet,,!offer:chainlink,,mainnet,,,,,,,,,,,,
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=celo-mainnet)""]",mainnet,,,,,,,,,,,,
 pyth-mainnet,,!offer:pyth,,mainnet,,,,,,,,,,,,
 quex-mainnet,,!offer:quex,,mainnet,,,,,,,,,,,,
 redstone-mainnet,,!offer:redstone,,mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/hedera/oracles.csv
+++ b/listings/specific-networks/hedera/oracles.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=hedera-mainnet)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/hyperliquid/oracles.csv
+++ b/listings/specific-networks/hyperliquid/oracles.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=hyperliquid-mainnet)""]",mainnet,,,,,,,,,,,,
 redstone-mainnet,,!offer:redstone,"[""[Docs](https://app.redstone.finance/push-feeds?size=32&networks=999,998,hyperevm,hyperliquid&testnets=true)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/ink/oracles.csv
+++ b/listings/specific-networks/ink/oracles.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=ink-mainnet)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/katana/oracles.csv
+++ b/listings/specific-networks/katana/oracles.csv
@@ -1,4 +1,4 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 api3,,!offer:api3,,mainnet,,,,,,,,,,,,
-chainlink,,!offer:chainlink,,mainnet,,,,,,,,,,,,
+chainlink,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=katara-mainnet)""]",mainnet,,,,,,,,,,,,
 redstone,,!offer:redstone,,mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/linea/oracles.csv
+++ b/listings/specific-networks/linea/oracles.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 api3-mainnet,,!offer:api3,,mainnet,,,,,,,,,,,,
-chainlink-mainnet,,!offer:chainlink,,mainnet,,,,,,,,,,,,
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=linea-mainnet)""]",mainnet,,,,,,,,,,,,
 chainlink-sepolia,,!offer:chainlink,,sepolia,,,,,,,,,,,,
 dia-mainnet,,!offer:dia,,mainnet,,,,,,,,,,,,
 eoracle-mainnet,,!offer:eoracle,,mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/plasma/oracles.csv
+++ b/listings/specific-networks/plasma/oracles.csv
@@ -1,5 +1,5 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
-chainlink-mainnet,,!offer:chainlink,,mainnet,,,,,,,,,,,,
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=plasma-mainnet)""]",mainnet,,,,,,,,,,,,
 chronicle-testnet,,!offer:chronicle,,testnet,,,,,,,,,,,,
 pyth-mainnet,,!offer:pyth,,mainnet,,,,,,,,,,,,
 redstone-mainnet,,!offer:redstone,,mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/tron/oracles.csv
+++ b/listings/specific-networks/tron/oracles.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 band-mainnet,,!offer:band,"[""[Docs](https://developers.tron.network/docs/band-oracle)""]",mainnet,,,,,,,,,,,,
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=tron-mainnet)""]",mainnet,,,,,,,,,,,,

--- a/listings/specific-networks/unichain/oracles.csv
+++ b/listings/specific-networks/unichain/oracles.csv
@@ -1,6 +1,7 @@
 slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitoringAndAnalytics,additionalFeatures,dataTypes,decentralizationModel,economicalSecurity,economicalSecurityNote,sdk,auditsPerformed,tag
 api3-mainnet,,!offer:api3,"[""[Docs](https://market.api3.org/unichain)""]",mainnet,,,,,,,,,,,,
 api3-testnet,,!offer:api3,"[""[Docs](https://market.api3.org/unichain-sepolia-testnet)""]",testnet,,,,,,,,,,,,
+chainlink-mainnet,,!offer:chainlink,"[""[Docs](https://docs.chain.link/data-feeds/price-feeds/addresses?network=unichain-mainnet)""]",mainnet,,,,,,,,,,,,
 chronicle-mainnet,,!offer:chronicle,"[""[Docs](https://chroniclelabs.org/dashboard/oracle/USDT/USD#blockchain=UNICHAIN&contract=0x8E947Ea7D5881Cd600Ace95F1201825F8C708844)""]",mainnet,,,,,,,,,,,,
 chronicle-testnet,,!offer:chronicle,"[""[Docs](https://chroniclelabs.org/dashboard/oracle/USDT/USD#testnet=true&blockchain=UNICHAIN-SEP&txn=0x00001215e8f9c3c4a3294df2b7f625160a7b114bc40539004a9b4f76a33f1e16&contract=0x9b2305fE37E7d58A9578cdcd3E21693539c6c4be)""]",testnet,,,,,,,,,,,,
 pyth-mainnet,,!offer:pyth,"[""[Docs](https://docs.pyth.network/price-feeds/core/contract-addresses/evm#mainnets)""]",mainnet,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Chainlink Data Feeds oracle rows for Botanix, Hedera, Ink, BOB, Hyperliquid, Tron, and Unichain where Chainlink lists mainnet feeds
- add official Chainlink Price Feed Addresses Docs links to existing blank Chainlink oracle rows for Celo, Katana, Linea, and Plasma
- keep CSV rows sorted by slug

## Source
- Chainlink Price Feed Contract Addresses: https://docs.chain.link/data-feeds/price-feeds/addresses
- Used the official `queryString` network identifiers from that page, e.g. `linea-mainnet`, `celo-mainnet`, `botanix-mainnet`

## Validation
- `python tools/validate_csv.py`
- `python tools/csv_to_json.py`
- `python tools/validate.py`

## Reward estimate
- 11 changed oracle rows
- 7 new rows, 4 existing rows with `actionButtons` filled
- 32 non-null added/improved CSV fields by local count
- Estimated at 0.06 USDC/field: 1.92 USDC, subject to maintainer review

Payout wallet (USDT/USDC ERC-20): `0x06f44f4839fd5df4f4670036d028b29dec939363`