### PR TITLE
Add Arbitrum Circle faucet action link

### DIFF
--- a/listings/specific-networks/arbitrum/faucets.csv
+++ b/listings/specific-networks/arbitrum/faucets.csv
@@ -1,7 +1,7 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,requiredMainnetBalance,price,dripLimitAmount,dripLimitPeriod,additionalNotes,starred,tag
 alchemy-sepolia-faucet,,!offer:alchemy-faucet,"[""[Faucet](https://www.alchemy.com/faucets/arbitrum-sepolia)""]",sepolia,,,,,,,,,
 chainlink-sepolia-faucet-eth,,!offer:chainlink-faucet,"[""[Faucet](https://faucets.chain.link/arbitrum-sepolia)""]",sepolia,,,,,,,,,
-circle-faucet-usdc,,!offer:circle-faucet-usdc,,sepolia,,,,,,,,,
+circle-faucet-usdc,,!offer:circle-faucet-usdc,"[""[Faucet](https://faucet.circle.com/)""]",sepolia,,,,,,,,,
 ethglobal-sepolia-faucet,,!offer:ethglobal-faucet,"[""[Faucet](https://ethglobal.com/faucet/arbitrum-sepolia-421614)""]",sepolia,,,,,,,,,
 getblock-sepolia-faucet,,!offer:getblock-faucet,"[""[Faucet](https://getblock.io/faucet/arb-sepolia/)""]",sepolia,,,,,0.1 ETH,,,,
 learnweb3-sepolia-faucet,,!offer:learnweb3-faucet,"[""[Faucet](https://learnweb3.io/faucets/arbitrum_sepolia/)""]",sepolia,,,,,,,,,


### PR DESCRIPTION
## Summary
Add the direct Circle faucet action link for the Arbitrum Sepolia USDC faucet listing.

## Type of change
- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: arbitrum
- Categories affected: faucets

- Additional notes, additional context / screenshots:
  - Adds the verified Circle faucet URL to the existing `circle-faucet-usdc` Arbitrum Sepolia listing.
  - Source verified:
    - https://faucet.circle.com/

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address (for data patching rewards): 0x185e250a54ced0d999cbc3280ca8481b35aa2ce0
- Twitter (X) post link (for +10% of rewards to this PR):
