### PR TITLE
Add missing oracle to Arbitrum (umbrella-network)

### DIFF
--- a/listings/specific-networks/arbitrum/oracles.csv
+++ b/listings/specific-networks/arbitrum/oracles.csv
@@ -25,5 +25,6 @@ supra-sepolia,,!offer:supra,"[""[Docs](https://docs.supra.com/oracles/data-feeds
 switchboard-one,,!offer:switchboard,"[""[Docs](https://docs.switchboard.xyz/docs-by-chain/evm)""]",one,,,,,,,,,,,,
 tellor-one,,!offer:tellor,"[""[Docs](http://docs.arbitrum.io/for-devs/oracles/trellor)""]",one,,,,,,,,,,,,
 uma-one,,!offer:uma,"[""[Docs](https://docs.uma.xyz/resources/network-addresses)""]",one,,,,,,,,,,,,
+umbrella-network-one,,!offer:umbrella-network,"[""[Docs](https://umbrella-network.github.io/technical-documentation/umbrella-network/docs/getting-started-1.html)""]",one,,,,,,,,,,,,
 witnet-one,,!offer:witnet,"[""[Docs](https://docs.witnet.io/smart-contracts/supported-chains)""]",one,,,,,,,,,,,,
 witnet-sepolia,,!offer:witnet,"[""[Docs](https://docs.witnet.io/smart-contracts/supported-chains)""]",sepolia,,,,,,,,,,,,


### PR DESCRIPTION
Add missing oracle to Arbitrum (umbrella-network).

All entries reference existing canonical offers from references/offers/oracles.csv.

Reward address: 0x0920555F38a7dfB2b8417262be2b82f7bCbf019c