### PR TITLE
Add multi-chain testnet faucets to Ethereum

### DIFF
--- a/listings/specific-networks/ethereum/faucets.csv
+++ b/listings/specific-networks/ethereum/faucets.csv
@@ -17,5 +17,6 @@ quicknode-hoodi,,!offer:quicknode-faucet,"[""[Docs](https://faucet.quicknode.com
 quicknode-sepolia,,!offer:quicknode-faucet,"[""[Docs](https://faucet.quicknode.com/drip)""]",sepolia,,,,,,,0.2,12,
 rockx-sepolia,,!offer:rockx-faucet,"[""[Docs](https://access.rockx.com/faucet-sepolia)""]",sepolia,,,,,,,0,24,
 stakely-hoodi,,!offer:stakely-faucet,"[""[Docs](https://stakely.io/faucet/ethereum-hoodi-testnet-eth)""]",hoodi,,,,,,,1,24,
+stakely-sepolia,,!offer:stakely-faucet,"[""[Docs](https://stakely.io/faucet/ethereum-sepolia-testnet-eth)""]",sepolia,,,,,,,1,24,
 tatum-hoodi,,!offer:tatum-faucet,"[""[Docs](https://tatum.io/faucets/hoodi)""]",hoodi,,,,,,,0.002,24,
 tatum-sepolia,,!offer:tatum-faucet,"[""[Docs](https://tatum.io/faucets/sepolia)""]",sepolia,,,,,,,0.002,24,


### PR DESCRIPTION
Add multi-chain testnet faucets to Ethereum

Multi-chain testnet faucet providers (Chainstack, QuickNode, Tatum, GetBlock, Stakely, etc.) added for each network with appropriate chain designation.

Reward address: 0x0920555F38a7dfB2b8417262be2b82f7bCbf019c