### PR TITLE
Add multi-chain testnet faucets to Somnia

### DIFF
--- a/listings/specific-networks/somnia/faucets.csv
+++ b/listings/specific-networks/somnia/faucets.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,price,starred,requiredMainnetBalance,dripLimitAmount,dripLimitPeriod,additionalNotes,tag
 google-cloud-faucet,,!offer:google-cloud-faucet,"[""[Faucet](https://cloud.google.com/application/web3/faucet/somnia/shannon)""]",testnet,,,,,,1 STT,,,
-somnia-faucet-testnet,,!offer:somnia-faucet,,testnet,,,,,,,,,
+somnia-faucet-testnet,,!offer:somnia-faucet,"[""[Faucet](https://testnet.somnia.network/)""]",testnet,,,,,,,,,
 stakely-faucet-mainnet,,!offer:stakely-faucet,"[""[Faucet](https://stakely.io/faucet/somnia-somi)""]",mainnet,,,,,,0.001 SOMI,,,
 stakely-faucet-testnet,,!offer:stakely-faucet,"[""[Faucet](https://stakely.io/faucet/somnia-testnet-stt)""]",testnet,,,,,,0.001 STT,,,
 thirdweb-faucet,,!offer:thirdweb-faucet,"[""[Faucet](https://thirdweb.com/somnia-shannon-testnet)""]",testnet,FALSE,TRUE,$5/$99/$499/$1499,FALSE,,,,"[""Available only on paid plans""]",


### PR DESCRIPTION
Add multi-chain testnet faucets to Somnia

Multi-chain testnet faucet providers (Chainstack, QuickNode, Tatum, GetBlock, Stakely, etc.) added for each network with appropriate chain designation.

Reward address: 0x0920555F38a7dfB2b8417262be2b82f7bCbf019c