### PR TITLE
Add Taiko Taikoscan explorer listing

### DIFF
--- a/listings/specific-networks/taiko/explorers.csv
+++ b/listings/specific-networks/taiko/explorers.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 blockscout-mainnet,,!offer:blockscout,,mainnet,,,,,,,,,,,
+taikoscan-mainnet,,!offer:etherscan,"[""[Explore](https://taikoscan.io/)"",""[Docs](https://info.taikoscan.io/what-is-taikoscan/)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/taiko/explorers.csv
+++ b/listings/specific-networks/taiko/explorers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 blockscout-mainnet,,!offer:blockscout,,mainnet,,,,,,,,,,,
-taikoscan-mainnet,,!offer:etherscan,"[""[Explore](https://taikoscan.io/)"",""[Docs](https://info.taikoscan.io/what-is-taikoscan/)""]",mainnet,,,,,,,,,,,
+taikoscan-mainnet,,!offer:etherscan,"[""[Explore](https://taikoscan.io/)"",""[Docs](https://info.taikoscan.io/what-is-taikoscan/)""]",mainnet,Etherscan,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Taikoscan as a Taiko mainnet explorer listing
- reuse the existing Etherscan explorer offer reference with Taiko-specific action buttons

## Sources
- Etherscan chainlist returns Taiko Mainnet with block explorer https://taikoscan.io/: https://api.etherscan.io/v2/chainlist
- Etherscan supported chains list Taiko Mainnet: https://docs.etherscan.io/supported-chains
- Taikoscan explorer resolves successfully: https://taikoscan.io/
- Taikoscan information center describes Taikoscan as a blockchain explorer for Taiko: https://info.taikoscan.io/what-is-taikoscan/

## Verification
- python3 git-hooks/pre-commit.py
- python3 targeted CSV row/reference/sort/logo check
- curl -L -I https://taikoscan.io/ via proxy
- curl -L -I https://info.taikoscan.io/what-is-taikoscan/ via proxy
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749