### PR TITLE
Add Gnosis GnosisScan explorer listing

### DIFF
--- a/listings/specific-networks/gnosis/explorers.csv
+++ b/listings/specific-networks/gnosis/explorers.csv
@@ -1,6 +1,7 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://gnosis.blockscout.com/)"",""[Docs](https://gnosis.blockscout.com/api-docs)""]",mainnet,,,,,,,,,,,
 blockscout-testnet,,!offer:blockscout,"[""[Explore](https://gnosis-chiado.blockscout.com/)"",""[Docs](https://gnosis-chiado.blockscout.com/api-docs)""]",testnet,,,,,,,,,,,
+gnosisscan-mainnet,,!offer:etherscan,"[""[Explore](https://gnosisscan.io/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",mainnet,,,,,,,,,,,
 oklink-mainnet,,!offer:oklink,"[""[Explore](https://www.oklink.com/gnosis)"",""[Docs](https://www.oklink.com/docs/en/#developer-tools)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/gnosis)"",""[Docs](https://docs.tenderly.co/platform/supported-networks)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-testnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/gnosis-chiado)"",""[Docs](https://docs.tenderly.co/platform/supported-networks)""]",testnet,,,,,,,,,,,

--- a/listings/specific-networks/gnosis/explorers.csv
+++ b/listings/specific-networks/gnosis/explorers.csv
@@ -1,7 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://gnosis.blockscout.com/)"",""[Docs](https://gnosis.blockscout.com/api-docs)""]",mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://gnosisscan.io/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,
 blockscout-testnet,,!offer:blockscout,"[""[Explore](https://gnosis-chiado.blockscout.com/)"",""[Docs](https://gnosis-chiado.blockscout.com/api-docs)""]",testnet,,,,,,,,,,,
-gnosisscan-mainnet,,!offer:etherscan,"[""[Explore](https://gnosisscan.io/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",mainnet,,,,,,,,,,,
 oklink-mainnet,,!offer:oklink,"[""[Explore](https://www.oklink.com/gnosis)"",""[Docs](https://www.oklink.com/docs/en/#developer-tools)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/gnosis)"",""[Docs](https://docs.tenderly.co/platform/supported-networks)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-testnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/gnosis-chiado)"",""[Docs](https://docs.tenderly.co/platform/supported-networks)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
Summary
- add GnosisScan as a Gnosis mainnet explorer listing
- reuse the existing Etherscan explorer offer reference with Gnosis-specific action buttons

Sources
- Etherscan chainlist returns Gnosis chain id 100 with block explorer https://gnosisscan.io/: https://api.etherscan.io/v2/chainlist
- Etherscan supported chains page is available and documents supported Etherscan-family chains: https://docs.etherscan.io/supported-chains

Verification
- targeted CSV row/reference/sort check
- python3 git-hooks/pre-commit.py
- curl -L -I https://gnosisscan.io/ via proxy
- curl -L -I https://docs.etherscan.io/supported-chains via proxy
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749