### PR TITLE
Add Avalanche Snowscan explorer listings

### DIFF
--- a/listings/specific-networks/avalanche/explorers.csv
+++ b/listings/specific-networks/avalanche/explorers.csv
@@ -18,4 +18,6 @@ jiffyscan-starter,,!offer:jiffyscan-starter,"[""[Explore](https://jiffyscan.xyz/
 oklink,,!offer:oklink,"[""[Explore](https://www.oklink.com/avalanche)""]",mainnet,,,,,,,,,,,
 okx,,!offer:okx,"[""[Explore](https://web3.okx.com/explorer/avalanche)""]",mainnet,,,,,,,,,,,
 routescan,,!offer:routescan,,mainnet,,,,,,,,,,,
+snowscan-mainnet,,!offer:etherscan,"[""[Explore](https://snowscan.xyz/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",mainnet,,,,,,,,,,,
+snowscan-testnet,,!offer:etherscan,"[""[Explore](https://testnet.snowscan.xyz/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",testnet,,,,,,,,,,,
 tokenterminal-explorer,,!offer:tokenterminal-explorer,"[""[Explore](https://tokenterminal.com/explorer/projects/avalanche)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
Summary
- add Snowscan explorer listings for Avalanche C-Chain and Fuji testnet
- reuse the existing Etherscan explorer offer reference with Avalanche-specific action buttons

Sources
- Etherscan chainlist returns Avalanche C-Chain with block explorer https://snowscan.xyz/: https://api.etherscan.io/v2/chainlist
- Etherscan chainlist returns Avalanche Fuji Testnet with block explorer https://testnet.snowscan.xyz/: https://api.etherscan.io/v2/chainlist
- Etherscan supported chains page is available for Etherscan-family chains: https://docs.etherscan.io/supported-chains

Verification
- duplicate PR search for snowscan returned 0 results
- targeted CSV row/reference/sort check
- python3 git-hooks/pre-commit.py
- curl -L -I https://snowscan.xyz/ via proxy
- curl -L -I https://testnet.snowscan.xyz/ via proxy
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749