### PR TITLE
Add Sei Seiscan explorer listings

### DIFF
--- a/listings/specific-networks/sei/explorers.csv
+++ b/listings/specific-networks/sei/explorers.csv
@@ -1,2 +1,4 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+seiscan-mainnet,,!offer:etherscan,"[""[Explore](https://seiscan.io/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",mainnet,,,,,,,,,,,
+seiscan-testnet,,!offer:etherscan,"[""[Explore](https://testnet.seiscan.io/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",testnet,,,,,,,,,,,
 tokenview-mainnet,,!offer:tokenview,"[""[Explore](https://tokenterminal.com/explorer/projects/sei-network)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
Summary
- add Seiscan explorer listings for Sei mainnet and testnet
- reuse the existing Etherscan explorer offer reference with Sei-specific action buttons

Sources
- Etherscan chainlist returns Sei Mainnet with block explorer https://seiscan.io/: https://api.etherscan.io/v2/chainlist
- Etherscan chainlist returns Sei Testnet with block explorer https://testnet.seiscan.io/: https://api.etherscan.io/v2/chainlist
- Etherscan supported chains page is available for Etherscan-family chains: https://docs.etherscan.io/supported-chains

Verification
- duplicate PR search for seiscan returned 0 results
- targeted CSV row/reference/sort check
- python3 git-hooks/pre-commit.py
- curl -L -I https://seiscan.io/ via proxy
- curl -L -I https://testnet.seiscan.io/ via proxy
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749