### PR TITLE
Align Blast Sepolia explorer URL

### DIFF
--- a/listings/specific-networks/blast/explorers.csv
+++ b/listings/specific-networks/blast/explorers.csv
@@ -1,5 +1,5 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 3xpl,,!offer:3xpl,"[""[Explore](https://3xpl.com/blast)""]",mainnet,,,,,,,,,,,
 etherscan-mainnet,,!offer:etherscan,"[""[Explore](https://blastscan.io/)""]",mainnet,,,,,,,,,,,
-etherscan-testnet,,!offer:etherscan,"[""[Explore](https://testnet.blastscan.io/)""]",testnet,,,,,,,,,,,
+etherscan-testnet,,!offer:etherscan,"[""[Explore](https://sepolia.blastscan.io/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",testnet,,,,,,,,,,,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/blast)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
Summary
- align the Blast testnet Etherscan explorer action button with the current Blast Sepolia URL
- add the Etherscan supported-chains docs link for the updated Etherscan-family explorer row

Sources
- Etherscan chainlist returns Blast Sepolia Testnet with block explorer https://sepolia.blastscan.io/: https://api.etherscan.io/v2/chainlist
- Etherscan supported chains page is available for Etherscan-family chains: https://docs.etherscan.io/supported-chains

Verification
- duplicate PR search for sepolia.blastscan returned 0 results
- targeted CSV row/reference/sort check
- python3 git-hooks/pre-commit.py
- curl -L -I https://sepolia.blastscan.io/ via proxy
- curl -L -I https://docs.etherscan.io/supported-chains via proxy
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749