### PR TITLE
Add opBNB testnet BscScan explorer listing

### DIFF
--- a/listings/specific-networks/opbnb/explorers.csv
+++ b/listings/specific-networks/opbnb/explorers.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 3xpl,,!offer:3xpl,"[""[Explore](https://3xpl.com/opbnb)""]",mainnet,,,,,,,,,,,
+bscscan-testnet,,!offer:bscscan,"[""[Explore](https://opbnb-testnet.bscscan.com/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
Summary
- add BscScan explorer listing for opBNB Testnet
- reuse the existing BscScan explorer offer reference with opBNB testnet-specific action buttons

Sources
- Etherscan chainlist returns opBNB Testnet with block explorer https://opbnb-testnet.bscscan.com/: https://api.etherscan.io/v2/chainlist
- Etherscan supported chains page is available for Etherscan-family chains: https://docs.etherscan.io/supported-chains

Verification
- duplicate PR search for opbnb-testnet.bscscan.com returned 0 results
- targeted opBNB CSV row/reference/sort check
- python3 git-hooks/pre-commit.py
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749