### PR TITLE
Add Taiko Hoodi Taikoscan explorer listing

### DIFF
--- a/listings/specific-networks/taiko/explorers.csv
+++ b/listings/specific-networks/taiko/explorers.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 blockscout-mainnet,,!offer:blockscout,,mainnet,,,,,,,,,,,
+taikoscan-testnet,,!offer:etherscan,"[""[Explore](https://hoodi.taikoscan.io/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
Summary
- add Taikoscan explorer listing for Taiko Hoodi testnet
- reuse the existing Etherscan explorer offer reference with Taiko testnet-specific action buttons

Sources
- Etherscan chainlist returns Taiko Hoodi with block explorer https://hoodi.taikoscan.io/: https://api.etherscan.io/v2/chainlist
- Etherscan supported chains page is available for Etherscan-family chains: https://docs.etherscan.io/supported-chains

Verification
- duplicate PR search for hoodi.taikoscan.io returned 0 results
- targeted Taiko CSV row/reference/sort check
- python3 git-hooks/pre-commit.py
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749