### PR TITLE
Add Berachain Berascan action buttons

### DIFF
--- a/listings/specific-networks/berachain/explorers.csv
+++ b/listings/specific-networks/berachain/explorers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-berascan-mainnet,,!offer:berascan,,mainnet,,,,,,,,,,,
-berascan-testnet,,!offer:berascan,,testnet,,,,,,,,,,,
+berascan-mainnet,,!offer:berascan,"[""[Explore](https://berascan.com/)"",""[Docs](https://docs.berachain.com/general/introduction/connect-to-berachain)""]",mainnet,,,,,,,,,,,
+berascan-testnet,,!offer:berascan,"[""[Explore](https://testnet.berascan.com/)"",""[Docs](https://docs.berachain.com/general/introduction/connect-to-berachain)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
Summary
- add Berascan action buttons for Berachain mainnet and testnet explorer rows
- keep the existing Berascan explorer offer references and point actions to the network-specific explorer URLs

Sources
- Etherscan chainlist returns Berachain Mainnet with block explorer https://berascan.com/: https://api.etherscan.io/v2/chainlist
- Etherscan chainlist returns Berachain Bepolia Testnet with block explorer https://testnet.berascan.com/: https://api.etherscan.io/v2/chainlist
- Berachain connection docs are linked from the canonical Berascan offer: https://docs.berachain.com/general/introduction/connect-to-berachain

Verification
- duplicate PR search for berascan.com and testnet.berascan.com returned 0 results
- targeted Berachain CSV row/reference/sort check
- python3 git-hooks/pre-commit.py
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

Rewards address (Ethereum Mainnet, ERC-20): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749