### PR TITLE
Add Polygon Polygonscan action button

### DIFF
--- a/listings/specific-networks/polygon/explorers.csv
+++ b/listings/specific-networks/polygon/explorers.csv
@@ -11,7 +11,7 @@ jiffyscan-starter,,!offer:jiffyscan-starter,"[""[Explore](https://jiffyscan.xyz/
 oklink-mainnet,,!offer:oklink,"[""[Explorer](https://www.oklink.com/polygon)""]",mainnet,,,,,,,,,,,
 okxexplorer-mainnet,,!offer:okx,"[""[Explorer](https://web3.okx.com/explorer/polygon)""]",mainnet,,,,,,,,,,,
 polygonscan-amoy,,!offer:polygonscan,"[""[Explorer](https://amoy.polygonscan.com/)""]",amoy,,,,,,,,,,,
-polygonscan-mainnet,,!offer:polygonscan,,mainnet,,,,,,,,,,,
+polygonscan-mainnet,,!offer:polygonscan,"[""[Explorer](https://polygonscan.com/)""]",mainnet,,,,,,,,,,,
 tokenterminal-explorer-mainnet,,!offer:tokenterminal-explorer,"[""[Explore](https://tokenterminal.com/explorer/projects/polygon)""]",mainnet,,,,,,,,,,,
 wormholescan-mainnet,,!offer:wormholescan,"[""[Explore](https://wormholescan.io/)""]",mainnet,,,,,,,,,,,
 wormholescan-testnet,,!offer:wormholescan,"[""[Explore](https://wormholescan.io/?network=TESTNET)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add the missing Polygon mainnet Polygonscan explorer action button
- keep the existing `!offer:polygonscan` reference and align the network row with the existing Amoy Polygonscan row

## Type of change
- [x] Update data rows

## Scope
- Networks affected: polygon
- Categories affected: explorers

- Additional notes, additional context / screenshots: Polygonscan mainnet is listed in Etherscan chainlist as https://polygonscan.com/.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- duplicate PR search for polygonscan.com returned 0 open results before implementation
- targeted Polygon CSV row/reference/sort/logo check
- python3 git-hooks/pre-commit.py
- curl -L https://api.etherscan.io/v2/chainlist via proxy
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
