### PR TITLE
Add Rootstock Blockscout action buttons

### DIFF
--- a/listings/specific-networks/rootstock/explorers.csv
+++ b/listings/specific-networks/rootstock/explorers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 blockchair-mainnet,,!offer:blockchair,,mainnet,,,,,,,,,,,
-blockscout-mainnet,,!offer:blockscout,,mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://rootstock.blockscout.com/)"",""[Docs](https://rootstock.blockscout.com/api-docs)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Rootstock-specific Blockscout action buttons for the existing mainnet explorer row
- keep the existing `!offer:blockscout` reference and point actions to the Rootstock explorer and API docs

## Type of change
- [x] Update data rows

## Scope
- Networks affected: rootstock
- Categories affected: explorers

- Additional notes, additional context / screenshots: The Rootstock Blockscout explorer and API docs both return HTTP 200.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- duplicate PR search for rootstock.blockscout.com returned 0 open/closed results before implementation
- targeted Rootstock CSV row/reference/sort/logo check
- curl -L -I https://rootstock.blockscout.com/ via proxy
- curl -L -I https://rootstock.blockscout.com/api-docs via proxy
- python3 git-hooks/pre-commit.py
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
