### PR TITLE
Add HashKey Blockscout action buttons

### DIFF
--- a/listings/specific-networks/hashkey/explorers.csv
+++ b/listings/specific-networks/hashkey/explorers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,,mainnet,,,,,,,,,,,
-blockscout-testnet,,!offer:blockscout,,testnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://hsk.blockscout.com/)""]",mainnet,,,,,,,,,,,
+blockscout-testnet,,!offer:blockscout,"[""[Explore](https://testnet-explorer.hskchain.net/)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add HashKey mainnet and testnet Blockscout explorer action buttons for the existing explorer rows
- keep the existing `!offer:blockscout` references and use the current canonical explorer URLs after redirects

## Type of change
- [x] Update data rows

## Scope
- Networks affected: hashkey
- Categories affected: explorers

- Additional notes, additional context / screenshots: The previous HashKey Blockscout URLs redirect to the current canonical explorer URLs used in this PR.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- duplicate PR search for hsk.blockscout.com returned 0 open/closed results before implementation
- duplicate PR search for testnet-explorer.hskchain.net returned 0 open/closed results before implementation
- targeted HashKey CSV row/reference/sort/logo check
- curl -L -I https://hsk.blockscout.com/ via proxy
- curl -L -I https://testnet-explorer.hskchain.net/ via proxy
- python3 git-hooks/pre-commit.py
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
