### PR TITLE
Add Taiko Blockscout action button

### DIFF
--- a/listings/specific-networks/taiko/explorers.csv
+++ b/listings/specific-networks/taiko/explorers.csv
@@ -1,2 +1,2 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,,mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://blockscoutapi.mainnet.taiko.xyz/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add the Taiko mainnet Blockscout explorer action button for the existing explorer row
- keep the existing `!offer:blockscout` reference and point the network row to the live Taiko Blockscout explorer

## Type of change
- [x] Update data rows

## Scope
- Networks affected: taiko
- Categories affected: explorers

- Additional notes, additional context / screenshots: The linked page returns HTTP 200 and identifies itself as Mainnet Taiko Explorer.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- duplicate PR search for blockscoutapi.mainnet.taiko.xyz returned 0 open/closed results before implementation
- broad Taiko Blockscout PR search only showed old closed setup-pack PRs, not this domain
- targeted Taiko CSV row/reference/sort/logo check
- curl -L -I https://blockscoutapi.mainnet.taiko.xyz/ via proxy
- fetched page text includes Mainnet Taiko Explorer and Blockscout
- python3 git-hooks/pre-commit.py
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
