### PR TITLE
Add Rootstock Blockchair action button

### DIFF
--- a/listings/specific-networks/rootstock/explorers.csv
+++ b/listings/specific-networks/rootstock/explorers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockchair-mainnet,,!offer:blockchair,,mainnet,,,,,,,,,,,
+blockchair-mainnet,,!offer:blockchair,"[""[Explore](https://blockchair.com/rootstock)""]",mainnet,,,,,,,,,,,
 blockscout-mainnet,,!offer:blockscout,,mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add the Rootstock mainnet Blockchair explorer action button for the existing explorer row
- keep the existing `!offer:blockchair` reference and point the network row to Blockchair's Rootstock explorer

## Type of change
- [x] Update data rows

## Scope
- Networks affected: rootstock
- Categories affected: explorers

- Additional notes, additional context / screenshots: Blockchair's Rootstock page returns HTTP 200 and follows the same network-specific URL pattern used by other Blockchair explorer rows.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- duplicate PR search for rootstock blockchair and blockchair.com/rootstock before implementation
- checked prior merged Rootstock PR #1554 to confirm the row was added empty and was not later intentionally cleared
- targeted Rootstock Blockchair CSV row/reference/logo check
- curl -L -I https://blockchair.com/rootstock via proxy
- python3 git-hooks/pre-commit.py
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
