### PR TITLE
Add BSC Blockchair action button

### DIFF
--- a/listings/specific-networks/bsc/explorers.csv
+++ b/listings/specific-networks/bsc/explorers.csv
@@ -2,7 +2,7 @@ slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additi
 3xpl,,!offer:3xpl,,mainnet,,,,,,,,,,,
 arkham,,!offer:arkham,,mainnet,,,,,,,,,,,
 bitquery,,!offer:bitquery,,mainnet,,,,,,,,,,,
-blockchair,,!offer:blockchair,,mainnet,,,,,,,,,,,
+blockchair,,!offer:blockchair,"[""[Explore](https://blockchair.com/bnb)""]",mainnet,,,,,,,,,,,
 bscscan-mainnet,Etherscan,,"[""[Explore](https://bscscan.com)"",""[Docs](https://docs.bscscan.com/)""]",mainnet,Etherscan,"[""Transactions"",""Tokens"",""Blocks"",""Contracts"",""Gas""]","[""Verified Contracts"",""Token Approvals"",""API Access"",""Bytecode to Opcode""]",TRUE,"[""REST API""]",,"[""Address"",""Transaction Hash"",""Block"",""Token"",""Contract""]",TRUE,TRUE,Free,
 bscscan-testnet,Etherscan,,"[""[Explore](https://testnet.bscscan.com)"",""[Docs](https://docs.bscscan.com/)""]",testnet,Etherscan,"[""Transactions"",""Tokens"",""Blocks"",""Contracts"",""Gas""]","[""Verified Contracts"",""Token Approvals"",""API Access"",""Bytecode to Opcode""]",TRUE,"[""REST API""]",,"[""Address"",""Transaction Hash"",""Block"",""Token"",""Contract""]",TRUE,TRUE,Free,
 bsctrace-mainnet,NodeReal,,"[""[Explore](https://bsctrace.com)""]",mainnet,Custom,"[""Transactions"",""Internal Tx"",""Blocks""]","[""Detailed Call Traces"",""Geth Debug Traces"",""Fast""]",FALSE,"[""REST API""]",,"[""Address"",""Transaction Hash""]",TRUE,TRUE,Free,


### PR DESCRIPTION
## Summary
- add the BSC mainnet Blockchair explorer action button for the existing explorer row
- keep the existing `!offer:blockchair` reference and point the network row to Blockchair's BNB explorer

## Type of change
- [x] Update data rows

## Scope
- Networks affected: bsc
- Categories affected: explorers

- Additional notes, additional context / screenshots: Blockchair's BNB page returns HTTP 200 and follows the same network-specific URL pattern used by other Blockchair explorer rows.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- duplicate PR search for bsc blockchair, blockchair bsc, and blockchair.com/bnb before implementation
- targeted BSC Blockchair CSV row/reference/logo check
- curl -L -I https://blockchair.com/bnb via proxy
- python3 git-hooks/pre-commit.py
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
