### PR TITLE
Add BSC OKLink action button

### DIFF
--- a/listings/specific-networks/bsc/explorers.csv
+++ b/listings/specific-networks/bsc/explorers.csv
@@ -12,7 +12,7 @@ jiffyscan-developer,,!offer:jiffyscan-developer,"[""[Explore](https://jiffyscan.
 jiffyscan-professional,,!offer:jiffyscan-professional,"[""[Explore](https://jiffyscan.xyz/pricing)""]",mainnet,,,,,,,,,,,
 jiffyscan-starter,,!offer:jiffyscan-starter,"[""[Explore](https://jiffyscan.xyz/pricing)""]",mainnet,,,,,,,,,,,
 metasleuth,,!offer:metasleuth,,mainnet,,,,,,,,,,,
-oklink,,!offer:oklink,,mainnet,,,,,,,,,,,
+oklink,,!offer:oklink,"[""[Explore](https://www.oklink.com/bsc)""]",mainnet,,,,,,,,,,,
 okx,,!offer:okx,,mainnet,,,,,,,,,,,
 tenderly-explorer,,!offer:tenderly-explorer,,mainnet,,,,,,,,,,,
 tokenterminal-explorer,,!offer:tokenterminal-explorer,"[""[Explore](https://tokenterminal.com/explorer/projects/bsc)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add the BSC mainnet OKLink explorer action button for the existing explorer row
- keep the existing `!offer:oklink` reference and point the network row to OKLink's BNB Chain explorer

## Type of change
- [x] Update data rows

## Scope
- Networks affected: bsc
- Categories affected: explorers

- Additional notes, additional context / screenshots: OKLink's BSC page returns HTTP 200 and identifies itself as the BNB Chain explorer.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- duplicate PR search for oklink bsc before implementation
- targeted BSC OKLink CSV row/reference/logo check
- curl -L -I https://www.oklink.com/bsc via proxy
- fetched OKLink page metadata/body identifying the page as BNB Chain explorer
- python3 git-hooks/pre-commit.py via proxy
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
