### PR TITLE
Add BSC 3xpl action button

### DIFF
--- a/listings/specific-networks/bsc/explorers.csv
+++ b/listings/specific-networks/bsc/explorers.csv
@@ -1,5 +1,5 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-3xpl,,!offer:3xpl,,mainnet,,,,,,,,,,,
+3xpl,,!offer:3xpl,"[""[Explore](https://3xpl.com/bnb)""]",mainnet,,,,,,,,,,,
 arkham,,!offer:arkham,,mainnet,,,,,,,,,,,
 bitquery,,!offer:bitquery,,mainnet,,,,,,,,,,,
 blockchair,,!offer:blockchair,,mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add the BSC mainnet 3xpl explorer action button for the existing explorer row
- keep the existing `!offer:3xpl` reference and point the network row to 3xpl's BNB explorer

## Type of change
- [x] Update data rows

## Scope
- Networks affected: bsc
- Categories affected: explorers

- Additional notes, additional context / screenshots: 3xpl's BNB page returns HTTP 200 and identifies itself as the BNB explorer for the chain previously known as Binance Smart Chain.

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): N/A

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Verification
- exact duplicate PR search for 3xpl.com/bnb before implementation
- targeted BSC 3xpl CSV row/reference/logo check
- curl -L -I https://3xpl.com/bnb via proxy
- fetched 3xpl BNB explorer metadata/body confirming the BNB explorer page
- python3 git-hooks/pre-commit.py via proxy
- git diff --check

## Optional
- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
