### PR TITLE
Add Plasma testnet Plasmascan explorer

### DIFF
--- a/listings/specific-networks/plasma/explorers.csv
+++ b/listings/specific-networks/plasma/explorers.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 plasmascan-mainnet,,!offer:etherscan,"[""[Explore](https://plasmascan.to/)""]",mainnet,,,,,,,,,,,
+plasmascan-testnet,,!offer:etherscan,"[""[Explore](https://testnet.plasmascan.to/)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Plasma testnet Plasmascan explorer listing using the existing Etherscan offer reference.

## Validation

- Confirmed Etherscan V2 chainlist lists Plasma Testnet (chain ID 9746) with block explorer https://testnet.plasmascan.to/
- Verified https://testnet.plasmascan.to/ returns HTTP 200 through the local proxy
- Ran `python3 git-hooks/pre-commit.py`
- Ran `git diff --check`
