### PR TITLE
Add Hemi Blockscout explorer listings

### DIFF
--- a/listings/specific-networks/hemi/explorers.csv
+++ b/listings/specific-networks/hemi/explorers.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.hemi.xyz/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,
+blockscout-testnet,,!offer:blockscout,"[""[Explore](https://testnet.explorer.hemi.xyz/)"",""[Docs](https://docs.blockscout.com/)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add Hemi mainnet and testnet Blockscout explorer listings using the existing Blockscout offer reference.

## Validation

- Confirmed Hemi docs list https://explorer.hemi.xyz and https://testnet.explorer.hemi.xyz as block explorer URLs
- Confirmed ChainID metadata lists Hemi mainnet (43111) and Hemi Sepolia (743111) with the same Blockscout explorers
- Verified both explorer URLs return HTTP 200 through the local proxy
- Ran `python3 git-hooks/pre-commit.py`
- Ran `git diff --check`
