### PR TITLE
Add Lisk Blockscout explorer listings

### DIFF
--- a/listings/specific-networks/lisk/explorers.csv
+++ b/listings/specific-networks/lisk/explorers.csv
@@ -1,0 +1,3 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://blockscout.lisk.com/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,
+blockscout-testnet,,!offer:blockscout,"[""[Explore](https://sepolia-blockscout.lisk.com/)"",""[Docs](https://docs.blockscout.com/)""]",testnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add Lisk mainnet and Sepolia testnet Blockscout explorer listings using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: lisk
- Categories affected: explorers

## Validation checklist

- [x] Confirmed Lisk docs reference Blockscout for Lisk Mainnet and Lisk Sepolia Testnet
- [x] Confirmed ChainID metadata lists Lisk mainnet (1135) and Lisk Sepolia Testnet (4202) with the same Blockscout explorers
- [x] Verified both explorer URLs return HTTP 200 through the local proxy
- [x] Ran `python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`
