### PR TITLE
Add GOAT Network Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/goat/explorers.csv
+++ b/listings/specific-networks/goat/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.goat.network/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the GOAT Network mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: goat
- Categories affected: explorers

## Validation checklist

- [x] Confirmed ChainID metadata lists GOAT Network chain ID 2345 with https://explorer.goat.network
- [x] Confirmed Chainlist page for chain ID 2345 lists https://explorer.goat.network as the explorer
- [x] Confirmed the explorer page identifies as a GOAT Network Blockscout explorer and describes transactions, smart contract verification, addresses, network activity, data, and APIs
- [x] Verified https://explorer.goat.network/ returns HTTP 200 through the local proxy
- [x] Confirmed exact GitHub PR search for `is:pr goat explorer` returned no results
- [x] Ran `python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
