### PR TITLE
Add Corn Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/corn/explorers.csv
+++ b/listings/specific-networks/corn/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://maizenet-explorer.usecorn.com/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Corn mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: corn
- Categories affected: explorers

## Validation checklist

- [x] Confirmed ChainID metadata lists Corn chain ID 21000000 with https://maizenet-explorer.usecorn.com as Corn Blockscout
- [x] Confirmed the explorer page identifies as a Corn Maizenet Blockscout explorer and describes transactions, smart contract verification, addresses, network activity, data, and APIs
- [x] Verified https://maizenet-explorer.usecorn.com/ returns HTTP 200 through the local proxy
- [x] Confirmed exact GitHub PR search for `is:pr maizenet-explorer.usecorn.com` returned no results
- [x] Ran `python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
