### PR TITLE
Add Kusama Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/kusama/explorers.csv
+++ b/listings/specific-networks/kusama/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://blockscout-kusama.polkadot.io/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Kusama mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: kusama
- Categories affected: explorers

## Validation checklist

- [x] Confirmed ChainID metadata lists Kusama chain ID 420420418 with https://blockscout-kusama.polkadot.io
- [x] Confirmed the explorer page identifies as a Kusama Asset Hub Blockscout explorer and describes transactions, smart contract verification, addresses, network activity, data, and APIs
- [x] Verified https://blockscout-kusama.polkadot.io/ returns HTTP 200 through the local proxy
- [x] Confirmed exact GitHub PR search for `is:pr blockscout-kusama.polkadot.io` returned no results
- [x] Ran `python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
