### PR TITLE
Add Etherlink Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/etherlink/explorers.csv
+++ b/listings/specific-networks/etherlink/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.etherlink.com/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Etherlink mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: etherlink
- Categories affected: explorers

## Validation checklist

- [x] Confirmed Etherlink docs list Etherlink Mainnet chain ID 42793 with block explorer https://explorer.etherlink.com
- [x] Confirmed the explorer page identifies as an Etherlink Blockscout explorer
- [x] Verified https://explorer.etherlink.com/ returns HTTP 200 through the local proxy
- [x] Confirmed exact GitHub PR search for `repo:Chain-Love/chain-love is:pr explorer.etherlink.com` returned no results
- [x] Ran `python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
