### PR TITLE
Add Degen Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/degen/explorers.csv
+++ b/listings/specific-networks/degen/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.degen.tips/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Degen mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: degen
- Categories affected: explorers

## Validation checklist

- [x] Confirmed ChainID metadata lists Degen Chain chain ID 666666666
- [x] Confirmed the explorer page identifies as a Degen Mainnet Blockscout explorer
- [x] Verified https://explorer.degen.tips/ returns HTTP 200 through the local proxy
- [x] Confirmed exact GitHub PR search for `repo:Chain-Love/chain-love is:pr explorer.degen.tips` returned no results
- [x] Ran `python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
