### PR TITLE
Add Shape Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/shape/explorers.csv
+++ b/listings/specific-networks/shape/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://shapescan.xyz/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Shape mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: shape
- Categories affected: explorers

## Validation checklist

- [x] Confirmed Shape docs list Shape mainnet chain ID 360 with block explorer https://shapescan.xyz
- [x] Confirmed the explorer page identifies as a Shape Mainnet Blockscout explorer
- [x] Verified https://shapescan.xyz/ returns HTTP 200 through the local proxy
- [x] Confirmed exact GitHub PR search for `repo:Chain-Love/chain-love is:pr shapescan.xyz` returned no results
- [x] Ran `python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
