### PR TITLE
Add Sophon Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/sophon/explorers.csv
+++ b/listings/specific-networks/sophon/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.sophon.xyz/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Sophon mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: sophon
- Categories affected: explorers

## Validation checklist

- [x] Confirmed Sophon docs list Sophon mainnet chain ID 50104 with block explorer https://explorer.sophon.xyz
- [x] Confirmed the explorer page identifies as Sophon Block Explorer
- [x] Verified https://explorer.sophon.xyz/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR search for `repo:Chain-Love/chain-love is:pr explorer.sophon.xyz` and found no matching PR result
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
