### PR TITLE
Add Vana Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/vana/explorers.csv
+++ b/listings/specific-networks/vana/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://vanascan.io/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Vana mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: vana
- Categories affected: explorers

## Validation checklist

- [x] Confirmed Vana docs list Mainnet explorer vanascan.io and the Vana SDK docs list Vana Mainnet chain ID 1480
- [x] Confirmed the explorer page identifies as a Vana blockchain explorer and its API docs are available at https://vanascan.io/api-docs
- [x] Verified https://vanascan.io/ and https://vanascan.io/api-docs return HTTP 200 through the local proxy
- [x] Checked GitHub PR search for `repo:Chain-Love/chain-love is:pr vanascan.io` and found no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
