### PR TITLE
Add Morph Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/morph/explorers.csv
+++ b/listings/specific-networks/morph/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.morph.network/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Morph mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: morph
- Categories affected: explorers

## Validation checklist

- [x] Confirmed Morph docs list Morph Mainnet chain ID 2818 with block explorer https://explorer.morph.network
- [x] Confirmed the explorer page identifies as a Morph Blockscout explorer
- [x] Verified https://explorer.morph.network/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR searches for `repo:Chain-Love/chain-love is:pr explorer.morph.network` and `repo:Chain-Love/chain-love is:pr morph Blockscout explorer`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
