### PR TITLE
Add Superposition Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/superposition/explorers.csv
+++ b/listings/specific-networks/superposition/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.superposition.so/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Superposition mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: superposition
- Categories affected: explorers

## Validation checklist

- [x] Confirmed Superposition docs list Superposition mainnet chain ID 55244 with block explorer https://explorer.superposition.so
- [x] Confirmed the Superposition docs Block Explorer page identifies the explorer as Blockscout
- [x] Confirmed the live explorer page identifies as a Superposition Blockscout explorer
- [x] Verified https://explorer.superposition.so/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR searches for `repo:Chain-Love/chain-love is:pr explorer.superposition.so` and `repo:Chain-Love/chain-love is:pr superposition Blockscout explorer`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
