### PR TITLE
Add ZetaChain Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/zetachain/explorers.csv
+++ b/listings/specific-networks/zetachain/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://zetascan.com/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the ZetaChain mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: zetachain
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local ZetaChain network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed the live explorer page title identifies as `ZetaChain Mainnet blockchain explorer - View ZetaChain Mainnet stats | Blockscout`
- [x] Verified https://zetascan.com/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR searches for `repo:Chain-Love/chain-love is:pr zetascan.com` and `repo:Chain-Love/chain-love is:pr ZetaChain Blockscout explorer`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
