### PR TITLE
Add Zora Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/zora/explorers.csv
+++ b/listings/specific-networks/zora/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.zora.energy/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Zora mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: zora
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local Zora network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed the live explorer page title identifies as `Zora blockchain explorer - View Zora stats | Blockscout`
- [x] Verified https://explorer.zora.energy/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR search for `repo:Chain-Love/chain-love is:pr explorer.zora.energy`, with no matching Chain-Love PR path
- [x] Cross-checked public chain metadata that lists Zora chain ID 7777777 with block explorer https://explorer.zora.energy
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
