### PR TITLE
Add Plume Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/plume/explorers.csv
+++ b/listings/specific-networks/plume/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.plume.org/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Plume mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: plume
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local Plume network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed Plume docs list Plume Mainnet chain ID 98866 with block explorer https://explorer.plume.org
- [x] Confirmed Plume smart contract verification docs use Blockscout verifier URLs for Plume explorers
- [x] Confirmed the live explorer page title identifies as `plume blockchain explorer - View plume stats | Blockscout`
- [x] Verified https://explorer.plume.org/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR search for `repo:Chain-Love/chain-love is:pr explorer.plume.org`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
