### PR TITLE
Add LightLink Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/lightlink/explorers.csv
+++ b/listings/specific-networks/lightlink/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://phoenix.lightlink.io/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the LightLink Phoenix mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: lightlink
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local LightLink network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed LightLink docs say the team implemented Blockscout for Phoenix (Mainnet) and Pegasus (Testnet)
- [x] Confirmed the live explorer page title identifies as `LightLink Phoenix Mainnet blockchain explorer - View LightLink Phoenix Mainnet stats | Blockscout`
- [x] Verified https://phoenix.lightlink.io/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR searches for `repo:Chain-Love/chain-love is:pr phoenix.lightlink.io` and `repo:Chain-Love/chain-love is:pr LightLink Blockscout explorer`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
