### PR TITLE
Add Manta Pacific Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/manta-pacific/explorers.csv
+++ b/listings/specific-networks/manta-pacific/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://pacific-explorer.manta.network/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Manta Pacific mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: manta-pacific
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local Manta Pacific network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed Manta Pacific info page lists Chain ID 169 and block explorer https://pacific-explorer.manta.network
- [x] Confirmed the live explorer page title identifies as `bedrock-manta-pacific blockchain explorer - View bedrock-manta-pacific stats | Blockscout`
- [x] Verified https://pacific-explorer.manta.network/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR searches for `repo:Chain-Love/chain-love is:pr pacific-explorer.manta.network` and `repo:Chain-Love/chain-love is:pr Manta Pacific Blockscout explorer`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
