### PR TITLE
Add XAI Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/xai/explorers.csv
+++ b/listings/specific-networks/xai/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.xai-chain.net/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the XAI mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: xai
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local XAI network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed XAI docs say Blockscout supports the Xai blockchain and list mainnet Blockscout
- [x] Confirmed the live explorer page title identifies as `XAI blockchain explorer - View XAI stats | Blockscout`
- [x] Verified https://explorer.xai-chain.net/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR searches for `repo:Chain-Love/chain-love is:pr explorer.xai-chain.net` and `repo:Chain-Love/chain-love is:pr XAI Blockscout explorer`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
