### PR TITLE
Add Bahamut Ftnscan explorer listing

### DIFF
--- a/listings/specific-networks/bahamut/explorers.csv
+++ b/listings/specific-networks/bahamut/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+ftnscan-mainnet,,!offer:blockscout,"[""[Explore](https://ftnscan.com/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the Bahamut mainnet Ftnscan / Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: bahamut
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local Bahamut network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed Bahamut docs list Bahamut Mainnet chain ID 5165 with explorer https://ftnscan.com/
- [x] Confirmed the live explorer page title identifies as `Bahamut Mainnet blockchain explorer - View Bahamut Mainnet stats`
- [x] Confirmed the live explorer page content identifies Ftnscan as a tool for inspecting and analyzing EVM based blockchains / Bahamut Networks
- [x] Verified https://ftnscan.com/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR search for `repo:Chain-Love/chain-love is:pr ftnscan.com`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
