### PR TITLE
Add IOTA EVM Blockscout explorer listing

### DIFF
--- a/listings/specific-networks/iota/explorers.csv
+++ b/listings/specific-networks/iota/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+iota-evm-blockscout,,!offer:blockscout,"[""[Explore](https://explorer.evm.iota.org/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the IOTA EVM mainnet Blockscout explorer listing using the existing Blockscout offer reference.

## Type of change

- [x] Add data rows

## Scope

- Networks affected: iota
- Categories affected: explorers

## Validation checklist

- [x] Confirmed the local IOTA network folder has a mainnet icon and no existing explorers.csv
- [x] Confirmed IOTA's official IOTA EVM product page lists Chain ID 8822 and Explorer URL https://explorer.evm.iotaledger.net / IOTA EVM Explorer
- [x] Confirmed the live Blockscout explorer at https://explorer.evm.iota.org/ identifies as IOTA EVM and contains Blockscout content
- [x] Verified https://explorer.evm.iota.org/ returns HTTP 200 through the local proxy
- [x] Checked GitHub PR searches for `repo:Chain-Love/chain-love is:pr explorer.evm.iota.org` and `repo:Chain-Love/chain-love is:pr "IOTA EVM" Blockscout`, with no matching Chain-Love PR path
- [x] Ran `/Users/ck/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 git-hooks/pre-commit.py`
- [x] Ran `git diff --check`

## Optional

- Rewards address (for data patching rewards): 0x282A1bAfcCbB5BBB122c76A15897DCa823a31749
- Twitter (X) post link (for +10% of rewards to this PR): N/A
