### PR TITLE
fix(validation): detect inconsistent chain values

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,10 +17,21 @@ jobs:
           python-version: '3.x'
       
       - name: Install dependencies
-        run: pip install --upgrade pip && pip install -r requirements.txt
+        run: pip install --upgrade pip && pip install -r tools/requirements.txt
 
-      - name: Run CSV to JSON
-        run: python3 csv_to_json.py
+      - name: Check tools
+        run: |
+          python3 -m compileall -q tools
+          python3 -m json.tool tools/schema.json > /dev/null
+          python3 tools/test_chain_validation.py
 
-      - name: Run validation script
-        run: python validate.py
+      - name: Validate generated JSON
+        run: |
+          git fetch --depth=1 origin main
+          mkdir -p validation-run
+          cp -R tools/. validation-run/
+          cp -R meta validation-run/
+          git archive origin/main listings references | tar -x -C validation-run
+          cd validation-run
+          python3 csv_to_json.py
+          python3 validate.py

--- a/README.md
+++ b/README.md
@@ -564,5 +564,24 @@ When asked to **remove a column**, an agent should:
 - **§5 Scenario 2** (column key removed everywhere):
   - Edit `tools/schema.json`: remove the column from every `$defs.<category>` where it appears.
   - Remove its entry from `meta/columns.json`.
-  - On `main`, remove the column from every affected category CSV (see **§5**).
+- On `main`, remove the column from every affected category CSV (see **§5**).
 
+---
+
+## 7. Chain-value consistency validation
+
+The validator checks generated network JSON for obvious contradictions between a
+row's `chain` value and network-specific signals in its slug or source URLs. For
+example, a `sepolia` slug must not be published with `chain=mainnet`, and a
+`mainnet` slug must not be published with `chain=calibnet`.
+
+The check is intentionally conservative:
+
+- generic `mainnet` and `testnet` signals accept their known aliases;
+- rows without an obvious signal are left for normal manual review;
+- intentional exceptions are recorded by exact `<network>/<slug>` key and a
+  non-empty reason in `tools/chain_validation_allowlist.json`.
+
+If a row is intentionally cross-network, add a short explanation to the matching
+allowlist entry and include that explanation in the pull request. Otherwise,
+correct the CSV `chain` value or the source-backed slug/URL before submitting.

--- a/README.md
+++ b/README.md
@@ -577,7 +577,12 @@ example, a `sepolia` slug must not be published with `chain=mainnet`, and a
 
 The check is intentionally conservative:
 
-- generic `mainnet` and `testnet` signals accept their known aliases;
+- generic `testnet` signals accept known testnet aliases such as `sepolia` and
+  `holesky`;
+- generic `mainnet` signals match `chain=mainnet`, the current network's
+  canonical chain value, or a documented network-scoped mainnet alias;
+- ambiguous chain-family labels such as `one` are not treated as global network
+  signals;
 - rows without an obvious signal are left for normal manual review;
 - intentional exceptions are recorded by exact `<network>/<slug>` key and a
   non-empty reason in `tools/chain_validation_allowlist.json`.

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ When asked to **remove a column**, an agent should:
 - **§5 Scenario 2** (column key removed everywhere):
   - Edit `tools/schema.json`: remove the column from every `$defs.<category>` where it appears.
   - Remove its entry from `meta/columns.json`.
-- On `main`, remove the column from every affected category CSV (see **§5**).
+  - On `main`, remove the column from every affected category CSV (see **§5**).
 
 ---
 

--- a/tools/chain_validation_allowlist.json
+++ b/tools/chain_validation_allowlist.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": {}
+}

--- a/tools/chain_validation_allowlist.json
+++ b/tools/chain_validation_allowlist.json
@@ -1,4 +1,29 @@
 {
   "version": 1,
-  "entries": {}
+  "entries": {
+    "arbitrum/chainlink-sepolia": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "arbitrum/onfinality-sepolia-free-plan-indexer": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "arbitrum/onfinality-sepolia-standard-plan-indexer": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "ethereum/onfinality-sepolia-standard-plan-indexer": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "ethereum/subquery-hoodi-pay-as-you-go-indexer": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "monad/chainlink-testnet": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "monad/chronicle-mainnet": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "monad/chronicle-testnet": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "monad/pyth-testnet": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "monad/redstone-testnet": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "monad/supra-testnet": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "monad/switchboard-testnet": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "optimism/alchemy-op-mainnet-free": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "optimism/alchemy-op-mainnet-pay-as-you-go": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "optimism/publicnode-op-sepolia-public-recent-state": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "sonic/tatum-mainnet-free-recent-state": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-free-full-archive": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-free-recent-state": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-pro-full-archive": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-pro-recent-state": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-scale-full-archive": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-scale-recent-state": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-starter-full-archive": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup.",
+    "zcash/crypto-apis-testnet-starter-recent-state": "Existing main data conflict: row predates this validator and should be handled in a dedicated source-backed data cleanup."
+  }
 }

--- a/tools/test_chain_validation.py
+++ b/tools/test_chain_validation.py
@@ -1,0 +1,102 @@
+import json
+import tempfile
+from pathlib import Path
+
+from validate import load_chain_validation_allowlist, rule_chain_values_consistent
+
+
+def _errors(item, *, network="example", allowlist=None):
+    return rule_chain_values_consistent(
+        [item],
+        {
+            "network": network,
+            "allowlist": allowlist or set(),
+        },
+    )
+
+
+def test_exact_chain_signal_matches():
+    assert not _errors({"slug": "rpc-sepolia", "chain": "sepolia"})
+
+
+def test_slug_signal_mismatch_fails():
+    errors = _errors({"slug": "rpc-sepolia", "chain": "mainnet"})
+
+    assert errors
+    assert "sepolia" in errors[0]
+
+
+def test_generic_testnet_matches_specific_testnet_signals():
+    assert not _errors({"slug": "rpc-sepolia", "chain": "testnet"})
+
+
+def test_mainnet_signal_matches_network_canonical_chain():
+    assert not _errors({"slug": "subscan-mainnet", "chain": "astar"}, network="astar")
+
+
+def test_network_specific_mainnet_aliases_are_not_global():
+    assert not _errors({"slug": "rpc-mainnet", "chain": "one"}, network="arbitrum")
+    assert _errors({"slug": "rpc-mainnet", "chain": "one"}, network="example")
+
+
+def test_url_signal_is_checked_even_when_slug_has_signal():
+    errors = _errors(
+        {
+            "slug": "rpc-mainnet",
+            "chain": "mainnet",
+            "actionButtons": ["[Docs](https://example.com/docs/sepolia)"],
+        }
+    )
+
+    assert errors
+    assert "sepolia" in errors[0]
+
+
+def test_chain_family_names_are_not_generic_mainnet_aliases():
+    errors = _errors({"slug": "rpc-mainnet", "chain": "one"})
+
+    assert errors
+    assert "mainnet" in errors[0]
+
+
+def test_allowlist_suppresses_exact_documented_exception():
+    item = {"slug": "rpc-sepolia", "chain": "mainnet"}
+
+    assert _errors(item, network="example")
+    assert not _errors(item, network="example", allowlist={"example/rpc-sepolia"})
+
+
+def test_allowlist_requires_non_empty_reasons():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "allowlist.json"
+
+        path.write_text(json.dumps({"entries": ["example/rpc-sepolia"]}))
+        try:
+            load_chain_validation_allowlist(path)
+        except ValueError as exc:
+            assert "entries" in str(exc)
+        else:
+            raise AssertionError("list-style allowlist entries must be rejected")
+
+        path.write_text(
+            json.dumps(
+                {"entries": {"example/rpc-sepolia": "intentional cross-network docs link"}}
+            )
+        )
+        assert load_chain_validation_allowlist(path) == {"example/rpc-sepolia"}
+
+
+def main():
+    test_exact_chain_signal_matches()
+    test_slug_signal_mismatch_fails()
+    test_generic_testnet_matches_specific_testnet_signals()
+    test_mainnet_signal_matches_network_canonical_chain()
+    test_network_specific_mainnet_aliases_are_not_global()
+    test_url_signal_is_checked_even_when_slug_has_signal()
+    test_chain_family_names_are_not_generic_mainnet_aliases()
+    test_allowlist_suppresses_exact_documented_exception()
+    test_allowlist_requires_non_empty_reasons()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -112,17 +112,19 @@ CHAIN_SIGNAL_TOKENS = (
     "goerli",
     "holesky",
     "nova",
-    "one",
     "pulsar",
 )
 CHAIN_SIGNAL_RE = re.compile(
     r"(?<![a-z0-9])(?:" + "|".join(CHAIN_SIGNAL_TOKENS) + r")(?![a-z0-9])",
     re.IGNORECASE,
 )
-MAINNET_CHAIN_ALIASES = {"mainnet", "one", "nova"}
+MAINNET_CHAIN_ALIASES = {"mainnet"}
 TESTNET_CHAIN_ALIASES = {
     "testnet",
     "devnet",
+    "amoy",
+    "coston",
+    "coston2",
     "sepolia",
     "hoodi",
     "calibnet",
@@ -130,6 +132,10 @@ TESTNET_CHAIN_ALIASES = {
     "goerli",
     "holesky",
     "pulsar",
+    "shibuya",
+}
+NETWORK_MAINNET_CHAIN_ALIASES = {
+    "arbitrum": {"one", "nova"},
 }
 
 
@@ -150,8 +156,6 @@ def load_chain_validation_allowlist(path=CHAIN_VALIDATION_ALLOWLIST_PATH):
             raise ValueError(
                 f"{path}: every 'entries' key must map to a non-empty reason"
             )
-        return set(entries)
-    if isinstance(entries, list) and all(isinstance(entry, str) for entry in entries):
         return set(entries)
     raise ValueError(
         f"{path}: expected an 'entries' object mapping exact keys to reasons"
@@ -184,11 +188,18 @@ def _url_signals(item):
     return signals
 
 
-def _chain_matches_signal(chain, signal):
+def _chain_matches_signal(chain, signal, network_name=None):
+    network_name = network_name.strip().lower() if isinstance(network_name, str) else None
     if chain == signal:
         return True
+    if chain == "testnet" and signal in TESTNET_CHAIN_ALIASES:
+        return True
     if signal == "mainnet":
-        return chain in MAINNET_CHAIN_ALIASES
+        return (
+            chain in MAINNET_CHAIN_ALIASES
+            or chain == network_name
+            or chain in NETWORK_MAINNET_CHAIN_ALIASES.get(network_name, set())
+        )
     if signal == "testnet":
         return chain in TESTNET_CHAIN_ALIASES
     return False
@@ -216,16 +227,20 @@ def rule_chain_values_consistent(data, context=None):
         if allowlist_key in allowlist:
             continue
 
-        slug_signals = _chain_signals_from_text(slug)
-        signals = slug_signals or _url_signals(item)
+        signals = _chain_signals_from_text(slug) | _url_signals(item)
         if not signals:
             continue
 
         normalized_chain = chain.strip().lower()
-        if any(_chain_matches_signal(normalized_chain, signal) for signal in signals):
+        conflicting_signals = sorted(
+            signal
+            for signal in signals
+            if not _chain_matches_signal(normalized_chain, signal, network_name)
+        )
+        if not conflicting_signals:
             continue
 
-        expected = ", ".join(sorted(signals))
+        expected = ", ".join(conflicting_signals)
         errors.append(
             f"Item {idx}: chain '{chain}' conflicts with network signal(s) "
             f"[{expected}] in '{slug}' for '{network_name}'. "

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -4,20 +4,24 @@ import json
 from jsonschema import Draft202012Validator
 from jsonpointer import resolve_pointer
 import copy
+from pathlib import Path
 
 class Validator:
     def __init__(self):
         self.rules = []
 
-    def add_rule(self, rule_func):
+    def add_rule(self, rule_func, *, with_context=False):
         """Add a new validation rule function."""
-        self.rules.append(rule_func)
+        self.rules.append((rule_func, with_context))
 
-    def validate(self, data):
+    def validate(self, data, context=None):
         """Run all registered validation rules."""
         errors = []
-        for rule in self.rules:
-            errors.extend(rule(data))
+        for rule, with_context in self.rules:
+            if with_context:
+                errors.extend(rule(data, context))
+            else:
+                errors.extend(rule(data))
         return errors
 
 def rule_slug_unique(data):
@@ -93,6 +97,142 @@ def rule_chain_is_lowercase(data):
             continue
         if not item["chain"].islower():
             errors.append(f"Item {idx}: chain must be lowercase: want '{item['chain'].lower()}', got '{item['chain']}'. Please check all categories for the current network.")
+    return errors
+
+
+CHAIN_VALIDATION_ALLOWLIST_PATH = Path(__file__).with_name("chain_validation_allowlist.json")
+CHAIN_SIGNAL_TOKENS = (
+    "mainnet",
+    "testnet",
+    "devnet",
+    "sepolia",
+    "hoodi",
+    "calibnet",
+    "fuji",
+    "goerli",
+    "holesky",
+    "nova",
+    "one",
+    "pulsar",
+)
+CHAIN_SIGNAL_RE = re.compile(
+    r"(?<![a-z0-9])(?:" + "|".join(CHAIN_SIGNAL_TOKENS) + r")(?![a-z0-9])",
+    re.IGNORECASE,
+)
+MAINNET_CHAIN_ALIASES = {"mainnet", "one", "nova"}
+TESTNET_CHAIN_ALIASES = {
+    "testnet",
+    "devnet",
+    "sepolia",
+    "hoodi",
+    "calibnet",
+    "fuji",
+    "goerli",
+    "holesky",
+    "pulsar",
+}
+
+
+def load_chain_validation_allowlist(path=CHAIN_VALIDATION_ALLOWLIST_PATH):
+    """Load exact network/slug exceptions for intentional cross-network rows."""
+    if not path.exists():
+        return set()
+
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+
+    entries = payload.get("entries", {}) if isinstance(payload, dict) else payload
+    if isinstance(entries, dict):
+        if not all(
+            isinstance(key, str) and isinstance(reason, str) and reason.strip()
+            for key, reason in entries.items()
+        ):
+            raise ValueError(
+                f"{path}: every 'entries' key must map to a non-empty reason"
+            )
+        return set(entries)
+    if isinstance(entries, list) and all(isinstance(entry, str) for entry in entries):
+        return set(entries)
+    raise ValueError(
+        f"{path}: expected an 'entries' object mapping exact keys to reasons"
+    )
+
+
+def _chain_signals_from_text(value):
+    if not isinstance(value, str):
+        return set()
+    return {match.group(0).lower() for match in CHAIN_SIGNAL_RE.finditer(value)}
+
+
+def _url_signals(item):
+    signals = set()
+
+    def visit(value):
+        if isinstance(value, str):
+            if "http://" in value.lower() or "https://" in value.lower():
+                signals.update(_chain_signals_from_text(value))
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+        elif isinstance(value, dict):
+            for child in value.values():
+                visit(child)
+
+    for key, value in item.items():
+        if key != "slug":
+            visit(value)
+    return signals
+
+
+def _chain_matches_signal(chain, signal):
+    if chain == signal:
+        return True
+    if signal == "mainnet":
+        return chain in MAINNET_CHAIN_ALIASES
+    if signal == "testnet":
+        return chain in TESTNET_CHAIN_ALIASES
+    return False
+
+
+def rule_chain_values_consistent(data, context=None):
+    """Reject obvious slug/URL chain contradictions in a generated network file."""
+    context = context or {}
+    network_name = context.get("network")
+    allowlist = context.get("allowlist", set())
+    errors = []
+
+    # Offer/reference tables are validated separately and do not have a
+    # specific-network folder context to compare against.
+    if not network_name:
+        return errors
+
+    for idx, item in enumerate(data):
+        chain = item.get("chain")
+        slug = item.get("slug")
+        if not isinstance(chain, str) or not isinstance(slug, str):
+            continue
+
+        allowlist_key = f"{network_name}/{slug}"
+        if allowlist_key in allowlist:
+            continue
+
+        slug_signals = _chain_signals_from_text(slug)
+        signals = slug_signals or _url_signals(item)
+        if not signals:
+            continue
+
+        normalized_chain = chain.strip().lower()
+        if any(_chain_matches_signal(normalized_chain, signal) for signal in signals):
+            continue
+
+        expected = ", ".join(sorted(signals))
+        errors.append(
+            f"Item {idx}: chain '{chain}' conflicts with network signal(s) "
+            f"[{expected}] in '{slug}' for '{network_name}'. "
+            "Correct the chain value or add the exact '<network>/<slug>' key "
+            "to tools/chain_validation_allowlist.json with a documented reason."
+        )
+
     return errors
 
 def has_unclosed_markdown(s: str) -> bool:
@@ -211,7 +351,7 @@ def check_schema_validation(schema_validator, data) -> bool:
 
     return len(errors) == 0
 
-def check_rules_validation(rules_validator, data) -> bool:
+def check_rules_validation(rules_validator, data, context=None) -> bool:
     """
     Validate a given set of data against a set of rules.
 
@@ -226,7 +366,7 @@ def check_rules_validation(rules_validator, data) -> bool:
     for category in data.keys():
         if category in ("columns", "schemaVersion", "meta"):
             continue
-        errors = rules_validator.validate(data[category])
+        errors = rules_validator.validate(data[category], context=context)
         for err in errors:
             had_errors = True
             print(f"Error validating {category}: {err}")
@@ -245,8 +385,10 @@ def check_rules_validation(rules_validator, data) -> bool:
 
     return not had_errors
 
-def check_validation(data, schema_validator, rules_validator) -> bool:
-    return check_schema_validation(schema_validator, data) and check_rules_validation(rules_validator, data)
+def check_validation(data, schema_validator, rules_validator, context=None) -> bool:
+    return check_schema_validation(schema_validator, data) and check_rules_validation(
+        rules_validator, data, context=context
+    )
 
 def load_csv_folder(folder) -> dict:
     from csv_to_json import load_csv_to_dict_list, normalize
@@ -291,6 +433,8 @@ def main():
     rules.add_rule(rule_provider_casing_consistent)
     rules.add_rule(rule_slug_kebab_case)
     rules.add_rule(rule_chain_is_lowercase)
+    rules.add_rule(rule_chain_values_consistent, with_context=True)
+    chain_validation_allowlist = load_chain_validation_allowlist()
 
     # Validate networks
     validator = Draft202012Validator(schema)
@@ -299,7 +443,16 @@ def main():
         data = None
         with open(f"json/{network_spec}", "r") as f:
             data = json.load(f)
-        if not check_validation(data=data, schema_validator=validator, rules_validator=rules):
+        context = {
+            "network": Path(network_spec).stem,
+            "allowlist": chain_validation_allowlist,
+        }
+        if not check_validation(
+            data=data,
+            schema_validator=validator,
+            rules_validator=rules,
+            context=context,
+        ):
             had_errors = True
 
     # Validate providers


### PR DESCRIPTION
Closes #1943

## Summary

- Pass the generated network filename into validation rules.
- Flag obvious contradictions between a row's `chain` value and network signals in its slug or source URLs.
- Check URL signals even when the slug already has a chain signal.
- Keep matching conservative: generic `testnet` accepts known testnet aliases; generic `mainnet` matches `chain=mainnet`, the current network's canonical chain value, or a documented network-scoped alias.
- Do not treat ambiguous labels such as `one` as global network signals or global mainnet aliases.
- Require exact-key allowlist entries with non-empty reasons, and document the current legacy `main` data exceptions separately from future validation failures.
- Restore CI so this branch compiles tools, runs focused regression tests, generates JSON from current `main` data, and validates the result.

## Type of change

- [ ] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [x] Schema change
- [x] Documentation/metadata only

## Scope

- Networks affected: generated network validation
- Categories affected: all generated categories with a `chain` field
- Additional notes: no production data rows are changed; this is a validator, CI, allowlist, and contributor-guidance change.

## Links

- Related issue / DB Improvement Proposal: Closes #1943

## Validation checklist

- [x] I followed the Style Guide and Column Definitions.
- [x] No external provider links or data rows were added; the changed documentation links are repository documentation links.
- [x] No provider/network entries were added or modified.
- [x] This is not a blind AI-generated submission: the logic was manually inspected and focused-tested.

## Validation

- `python3 -m compileall -q tools`
- `python3 -m json.tool tools/schema.json`
- `python3 -m json.tool tools/chain_validation_allowlist.json`
- `python3 tools/test_chain_validation.py`
- Full CSV-to-JSON generation and validation passed against the current `main` snapshot.

## Reward

Reward address (Ethereum Mainnet USDC/USDT): `0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9`

AI disclosure: this patch was prepared with AI assistance; the changed logic was manually inspected and focused-tested.
