### PR TITLE
feat(schema): add normalized API authentication methods

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,26 +1,28 @@
-name: "Validate JSON"
+name: "Validate JSON tooling"
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
-  validate:
+  validate-tools:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      
+
       - name: Install dependencies
-        run: pip install --upgrade pip && pip install -r requirements.txt
+        run: python -m pip install --upgrade pip && python -m pip install -r tools/requirements.txt
 
-      - name: Run CSV to JSON
-        run: python3 csv_to_json.py
+      - name: Check Python tooling
+        run: python -m compileall -q tools
 
-      - name: Run validation script
-        run: python validate.py
+      - name: Check JSON schema
+        run: python -m json.tool tools/schema.json > /dev/null

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,11 +1,11 @@
-name: "Validate JSON tooling"
+name: "Validate JSON"
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
-  validate-tools:
+  validate:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,3 +26,17 @@ jobs:
 
       - name: Check JSON schema
         run: python -m json.tool tools/schema.json > /dev/null
+
+      - name: Run focused authentication metadata tests
+        run: python tools/test_authentication_methods.py
+
+      - name: Validate current data with proposed tools
+        run: |
+          git fetch --depth=1 origin main
+          mkdir -p validation-run
+          cp -R tools/. validation-run/
+          cp -R meta validation-run/
+          git archive origin/main references listings | tar -x -C validation-run
+          cd validation-run
+          python csv_to_json.py
+          python validate.py

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This guide explains how to **add new categories and columns for the Chain.Love p
 Data files are not documented in detail in this guide. Their structure and contribution flow are described in the `main` branch README: [README.md](https://github.com/Chain-Love/chain-love/blob/main/README.md).  
 However, schema/meta changes in this branch must be mirrored in data tables on `main` (for example when adding/removing categories or columns).
 
+### Optional API authentication metadata
+
+`apis.authenticationMethods` is an optional JSON array containing only verified
+credential methods: `none`, `api_key`, `bearer_token`, `jwt`, `basic_auth`,
+`oauth2`, `mtls`, or `wallet_signature`. An empty cell means the method has not
+been verified; `none` cannot be combined with another value, and duplicate
+values are invalid. Existing CSV rows may omit this optional column while a
+table is being backfilled; the loader treats the omitted value as blank.
+
 ---
 
 ## 1. Files and responsibilities
@@ -565,4 +574,3 @@ When asked to **remove a column**, an agent should:
   - Edit `tools/schema.json`: remove the column from every `$defs.<category>` where it appears.
   - Remove its entry from `meta/columns.json`.
   - On `main`, remove the column from every affected category CSV (see **§5**).
-

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -285,6 +285,17 @@
     "cellType": "arrayPopover",
     "group": "capabilities"
   },
+  "authenticationMethods": {
+    "key": "authenticationMethods",
+    "label": "Authentication Methods",
+    "icon": "lucide:KeyRound",
+    "description": "Credential or authentication methods officially supported or required for an API. Leave blank when unverified; none is exclusive.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
   "monitoringAndAnalytics": {
     "key": "monitoringAndAnalytics",
     "label": "Monitoring & Analytics",

--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -14,6 +14,11 @@ SDK_TBD_FIELDS = (
     "license",
 )
 
+# Optional columns may be introduced before existing columns without forcing a
+# rewrite of every legacy row. Only columns listed here may be absent from an
+# otherwise well-formed row.
+OPTIONAL_CSV_COLUMNS = {"authenticationMethods"}
+
 
 def col_letter(idx: int) -> str:
     """Convert 0-based index to Excel column letters."""
@@ -198,6 +203,24 @@ def scan_for_unexpected_unicode(file_path: str):
                 )
 
 
+def pad_missing_optional_columns(header: list[str], raw_row: list[str]) -> list[str] | None:
+    """Insert blank cells for optional columns omitted by legacy CSV rows."""
+    missing_count = len(header) - len(raw_row)
+    if missing_count <= 0:
+        return raw_row
+
+    optional_positions = [
+        index for index, column in enumerate(header)
+        if column in OPTIONAL_CSV_COLUMNS
+    ]
+    if len(optional_positions) != missing_count:
+        return None
+
+    for position in reversed(optional_positions):
+        raw_row.insert(position, "")
+    return raw_row
+
+
 def load_csv_to_dict_list(file_path: str) -> list[dict] | None:
     if file_path is None:
         return None
@@ -223,6 +246,11 @@ def load_csv_to_dict_list(file_path: str) -> list[dict] | None:
         row_number = 2  # header is row 1
 
         for raw_row in reader:
+            if len(raw_row) < expected_cols:
+                padded_row = pad_missing_optional_columns(header, raw_row)
+                if padded_row is not None:
+                    raw_row = padded_row
+
             if len(raw_row) != expected_cols:
                 errors.append(
                     f"{file_path}: Row {row_number} has {len(raw_row)} columns, expected {expected_cols}"

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -90,6 +90,30 @@
           "type": "string",
           "examples": ["EVM JSON-RPC", "The Graph"]
         },
+        "authenticationMethods": {
+          "type": ["array", "null"],
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "none",
+              "api_key",
+              "bearer_token",
+              "jwt",
+              "basic_auth",
+              "oauth2",
+              "mtls",
+              "wallet_signature"
+            ]
+          },
+          "not": {
+            "type": "array",
+            "minItems": 2,
+            "contains": {"const": "none"}
+          },
+          "description": "Credential or authentication methods officially supported or required for calling the API endpoint. Blank means the method has not been verified; none is exclusive."
+        },
         "additionalFeatures": {
           "type": ["array", "null"],
           "items": { "type": "string" }

--- a/tools/test_authentication_methods.py
+++ b/tools/test_authentication_methods.py
@@ -94,9 +94,21 @@ def test_schema_rejects_duplicate_authentication_methods():
     assert_invalid(item)
 
 
+def test_schema_rejects_empty_authentication_methods():
+    item = base_api_item()
+    item["authenticationMethods"] = []
+    assert_invalid(item)
+
+
 def test_schema_rejects_none_combined_with_other_methods():
     item = base_api_item()
     item["authenticationMethods"] = ["none", "api_key"]
+    assert_invalid(item)
+
+
+def test_schema_rejects_unknown_authentication_methods():
+    item = base_api_item()
+    item["authenticationMethods"] = ["session_cookie"]
     assert_invalid(item)
 
 
@@ -185,7 +197,9 @@ def main():
     test_schema_accepts_expected_authentication_methods()
     test_schema_allows_blank_authentication_methods()
     test_schema_rejects_duplicate_authentication_methods()
+    test_schema_rejects_empty_authentication_methods()
     test_schema_rejects_none_combined_with_other_methods()
+    test_schema_rejects_unknown_authentication_methods()
     test_loader_pads_legacy_rows_that_omit_optional_authentication_methods()
 
 

--- a/tools/test_authentication_methods.py
+++ b/tools/test_authentication_methods.py
@@ -1,0 +1,193 @@
+import csv
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from csv_to_json import load_csv_to_dict_list, normalize
+
+
+def schema_for_apis():
+    with open(Path(__file__).with_name("schema.json"), encoding="utf-8") as f:
+        schema = json.load(f)
+    return {
+        "$schema": schema["$schema"],
+        "$defs": schema["$defs"],
+        "type": "object",
+        "properties": {
+            "apis": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/apis"},
+            }
+        },
+        "required": ["apis"],
+        "additionalProperties": False,
+    }
+
+
+def assert_valid(item):
+    validator = Draft202012Validator(schema_for_apis())
+    errors = sorted(
+        validator.iter_errors({"apis": [item]}),
+        key=lambda error: list(error.absolute_path),
+    )
+    assert not errors, [error.message for error in errors]
+
+
+def assert_invalid(item):
+    validator = Draft202012Validator(schema_for_apis())
+    errors = list(validator.iter_errors({"apis": [item]}))
+    assert errors, "expected schema validation to fail"
+
+
+def base_api_item():
+    return {
+        "slug": "example-api",
+        "provider": "Example",
+        "offer": "Example API",
+        "actionButtons": None,
+        "planName": "Free",
+        "planType": "Free",
+        "historicalData": "Recent state",
+        "apiType": "RPC",
+        "chain": "mainnet",
+        "technology": "EVM JSON-RPC",
+        "accessPrice": "$0",
+        "queryPrice": "$0",
+        "starred": False,
+        "trial": False,
+        "availableApis": None,
+        "limitations": None,
+        "securityImprovements": None,
+        "monitoringAndAnalytics": None,
+        "regions": None,
+        "additionalFeatures": None,
+        "address": None,
+        "tag": None,
+        "uptimeSla": None,
+        "verifiedUptime": None,
+        "blocksBehindSla": None,
+        "verifiedBlocksBehindAvg": None,
+        "bandwidthSla": None,
+        "verifiedLatency": None,
+        "supportSla": None,
+    }
+
+
+def test_schema_accepts_expected_authentication_methods():
+    item = base_api_item()
+    item["authenticationMethods"] = ["api_key", "jwt"]
+    assert_valid(item)
+
+
+def test_schema_allows_blank_authentication_methods():
+    item = base_api_item()
+    item["authenticationMethods"] = None
+    assert_valid(item)
+
+
+def test_schema_rejects_duplicate_authentication_methods():
+    item = base_api_item()
+    item["authenticationMethods"] = ["jwt", "jwt"]
+    assert_invalid(item)
+
+
+def test_schema_rejects_none_combined_with_other_methods():
+    item = base_api_item()
+    item["authenticationMethods"] = ["none", "api_key"]
+    assert_invalid(item)
+
+
+def test_loader_pads_legacy_rows_that_omit_optional_authentication_methods():
+    header = [
+        "slug",
+        "provider",
+        "offer",
+        "actionButtons",
+        "planName",
+        "planType",
+        "historicalData",
+        "apiType",
+        "technology",
+        "authenticationMethods",
+        "accessPrice",
+        "queryPrice",
+        "starred",
+        "trial",
+        "availableApis",
+        "limitations",
+        "securityImprovements",
+        "monitoringAndAnalytics",
+        "regions",
+        "additionalFeatures",
+        "address",
+        "tag",
+        "uptimeSla",
+        "verifiedUptime",
+        "blocksBehindSla",
+        "verifiedBlocksBehindAvg",
+        "bandwidthSla",
+        "verifiedLatency",
+        "supportSla",
+    ]
+    legacy_row = [
+        "legacy-api",
+        "Example",
+        "Legacy API",
+        "",
+        "Free",
+        "Free",
+        "Recent state",
+        "RPC",
+        "EVM JSON-RPC",
+        "$0",
+        "$0",
+        "FALSE",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+    ]
+
+    with tempfile.NamedTemporaryFile("w", newline="", delete=False) as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerow(legacy_row)
+        temp_path = f.name
+
+    try:
+        data, errors = normalize({"apis": load_csv_to_dict_list(temp_path)})
+    finally:
+        os.unlink(temp_path)
+
+    assert not errors
+    item = data["apis"][0]
+    assert item["authenticationMethods"] is None
+    assert item["accessPrice"] == "$0"
+    assert item["queryPrice"] == "$0"
+
+
+def main():
+    test_schema_accepts_expected_authentication_methods()
+    test_schema_allows_blank_authentication_methods()
+    test_schema_rejects_duplicate_authentication_methods()
+    test_schema_rejects_none_combined_with_other_methods()
+    test_loader_pads_legacy_rows_that_omit_optional_authentication_methods()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements the schema/tooling half of DBIP #2471:

- Adds optional authenticationMethods metadata to the API schema.
- Restricts values to the documented enum.
- Rejects empty arrays, duplicates, and none combined with another method.
- Allows legacy CSV rows to omit this optional column during incremental backfill.
- Adds UI metadata and contributor documentation.

The corresponding data PR adds source-backed examples and links back to #2471.

## Type of change

- [x] Schema change
- [x] Documentation/metadata only

## Scope

- Networks affected: global API schema
- Categories affected: apis
- Additional notes: existing rows remain valid while the optional field is backfilled.

## Links

- Related DB Improvement Proposal: #2471

## Validation checklist

- [x] I followed the Style Guide and Column Definitions.
- [x] I personally opened and verified the documentation/source links used for this change.
- [x] I verified the schema behavior and the legacy-row compatibility path locally.
- [x] This PR is not a blind AI-generated submission: the logic was manually inspected and focused-tested.

## Validation

- Python syntax and JSON syntax checks passed.
- Direct schema cases passed for api_key and [api_key, jwt].
- Direct schema cases rejected duplicates, none + api_key, empty arrays, and unknown values.
- Full CSV-to-JSON generation and validation passed against the current main snapshot.

## Optional

- Rewards address: 0x820a7bf90d944bb26bfD9b62Ab172Fc3A0829cB9
- AI disclosure: prepared with AI assistance; the changed logic was manually inspected and focused-tested.