### PR TITLE
Extend Nownodes entries

### DIFF
--- a/listings/specific-networks/filecoin/apis.csv
+++ b/listings/specific-networks/filecoin/apis.csv
@@ -54,6 +54,7 @@ nodit-mainnet-dedicated-recent-state,,!offer:nodit-dedicated-recent-state,"[""[D
 nownodes-mainnet-business,,!offer:nownodes-business-recent-state,"[""[Buy](https://nownodes.io/pricing)"",""[Docs](https://nownodes.gitbook.io/fil-filecoin/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 nownodes-mainnet-enterprise,,!offer:nownodes-enterprise-recent-state,"[""[Buy](https://nownodes.io/pricing)"",""[Docs](https://nownodes.gitbook.io/fil-filecoin/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 nownodes-mainnet-free,,!offer:nownodes-free-recent-state,"[""[Website](https://nownodes.io/nodes/filecoin-fil)"",""[Docs](https://nownodes.gitbook.io/fil-filecoin/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+nownodes-mainnet-free-recent-state,,!offer:nownodes-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 nownodes-mainnet-pro,,!offer:nownodes-pro-recent-state,"[""[Buy](https://nownodes.io/pricing)"",""[Docs](https://nownodes.gitbook.io/fil-filecoin/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 spectrum-mainnet-business-recent-state,,!offer:spectrum-business-recent-state,"[""[Website](https://spectrumnodes.com/networks/filecoin-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 spectrum-mainnet-developer-recent-state,,!offer:spectrum-developer-recent-state,"[""[Website](https://spectrumnodes.com/networks/filecoin-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Added listing data for existing offers in APIs. Listing rows added: 1. Example listing slug: `nownodes-mainnet-free-recent-state`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: mainnet
- **Categories affected**: APIs
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @targetspartan97-create.

CSV preview:
```csv
nownodes-mainnet-free-recent-state,,!offer:nownodes-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `listings/specific-networks/<chain>/<category>.csv` for chain-scoped entries
  - `references/offers/<category>.csv` for offer entries
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): 0xac0F824579fa5f1e24b6665E9CA2B5088C3105dC
- Twitter (X) post link (for +10% of rewards to this PR): Not provided