### PR TITLE
Extend Arkham entries

### DIFF
--- a/listings/specific-networks/ethereum/explorers.csv
+++ b/listings/specific-networks/ethereum/explorers.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 3xpl-mainnet,,!offer:3xpl,"[""[Explore](https://3xpl.com/ethereum)""]",mainnet,,,,,,,,,,,
+arkham-mainnet,,!offer:arkham,,mainnet,,,,,,,,,,,
 beaconchain-mainnet,,!offer:beaconchain,"[""[Explore](https://beaconcha.in/)""]",mainnet,,,,,,,,,,,
 blockchair-mainnet,,!offer:blockchair,"[""[Explore](https://blockchair.com/ethereum)""]",mainnet,,,,,,,,,,,
 blockcypher-mainnet,,!offer:blockcypher,"[""[Explore](https://live.blockcypher.com/eth/)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Added listing data for existing offers in Explorers. Listing rows added: 1. Example listing slug: `arkham-mainnet`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: mainnet
- **Categories affected**: Explorers
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @targetspartan97-create.

CSV preview:
```csv
arkham-mainnet,,!offer:arkham,,mainnet,,,,,,,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `listings/specific-networks/<chain>/<category>.csv` for chain-scoped entries
  - `references/offers/<category>.csv` for offer entries
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): Not provided
- Twitter (X) post link (for +10% of rewards to this PR): Not provided