### PR TITLE
Fix plain-text offer rows in listings (DBIP #1955)

### DIFF
--- a/listings/all-networks/storages.csv
+++ b/listings/all-networks/storages.csv
@@ -17,5 +17,5 @@ storj-advanced,,!offer:storj-advanced,,,,,,,,
 storj-standard,,!offer:storj-standard,,,,,,,,
 swarm,,!offer:swarm,,,,,,,,
 tableland-db,Tableland,,"[""[Website](https://tableland.xyz/)""]",Database,"[""Decentralized database"",""SQL database"",""SQLite""]",Custom,TBD,,"It allows developers to store, manage, and query structured data for decentralized applications using familiar SQL statements, with access control and ownership tied to the blockchain",FALSE
-thread-db,Powergate,Thread DB,"[""[Docs](https://docs.textile.io/threads/)""]",Database,"[""Decentralized database"",""P2P database""]",Custom,TBD,,"It is a multi-party,decentralized database solution built on IPFS and Libp2p that provides an alternative architecture for data on the web",FALSE
+thread-db,Powergate,,"[""[Docs](https://docs.textile.io/threads/)""]",Database,"[""Decentralized database"",""P2P database""]",Custom,TBD,,"It is a multi-party,decentralized database solution built on IPFS and Libp2p that provides an alternative architecture for data on the web",FALSE
 zeeve-enterprise,,!offer:zeeve-enterprise,,,,,,,,

--- a/listings/specific-networks/avalanche/sdks.csv
+++ b/listings/specific-networks/avalanche/sdks.csv
@@ -2,13 +2,13 @@ slug,provider,offer,actionButtons,toolType,programmingLanguage,tag,description,p
 alchemy-sdk-free,,!offer:alchemy-sdk-free,,,,,,,,,,,,,,,
 alchemy-sdk-pay-as-you-go,,!offer:alchemy-sdk-pay-as-you-go,,,,,,,,,,,,,,,
 anyalt,,!offer:anyalt,,,,,,,,,,,,,,,
-avacloud-sdk,Ava Labs,SDK,"[""[Website](https://developers.avacloud.io/avalanche-sdk/overview)""]",SDK,TypeScript,"[""Web3 development"",""Avalanche"",""AvaCloud API"",""SDK""]","It is a legacy TypeScript SDK for interacting with the AvaCloud API and enterprise services, which is currently migrating to ChainKit",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
+avacloud-sdk,Ava Labs,,"[""[Website](https://developers.avacloud.io/avalanche-sdk/overview)""]",SDK,TypeScript,"[""Web3 development"",""Avalanche"",""AvaCloud API"",""SDK""]","It is a legacy TypeScript SDK for interacting with the AvaCloud API and enterprise services, which is currently migrating to ChainKit",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
 avalanche-sdk-chainkit,,!offer:avalanche-sdk-chainkit,,,,,,,,,,,,,,,
 avalanche-sdk-client,,!offer:avalanche-sdk-client,,,,,,,,,,,,,,,
 avalanche-sdk-interchain,,!offer:avalanche-sdk-interchain,,,,,,,,,,,,,,,
-avalanche-tooling-sdk-go,Ava Labs,SDK,"[""[NPM](https://www.npmjs.com/package/@avalanche-sdk/chainkit)""]",SDK,Go,"[""Golang SDK"",""Node provider"",""Subnet architecture""]","It is a Golang-based development kit utilized primarily for Avalanche node operations, network validators, and custom Subnet creation",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
-avalanche-wallet-sdk,Ava Labs,SDK,"[""[NPM](https://www.npmjs.com/package/@avalanche-sdk/client)""]",SDK,TypeScript,"[""Wallet SDK"",""Crypto wallet integration"",""Avalanche""]","It is a dedicated library for creating, managing, and authenticating decentralized non-custodial wallets specifically on the Avalanche network",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
-avalanchejs,Ava Labs,SDK,"[""[YARM](https://classic.yarnpkg.com/en/package/@avalanche-sdk/interchain)""]",SDK,TypeScript,"[""Web3 development"",""Blockchain framework"",""Avalanche""]","It is the classic Avalanche Platform JavaScript library for interfacing directly with the X-Chain, P-Chain, and C-Chain environments",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
+avalanche-tooling-sdk-go,Ava Labs,,"[""[NPM](https://www.npmjs.com/package/@avalanche-sdk/chainkit)""]",SDK,Go,"[""Golang SDK"",""Node provider"",""Subnet architecture""]","It is a Golang-based development kit utilized primarily for Avalanche node operations, network validators, and custom Subnet creation",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
+avalanche-wallet-sdk,Ava Labs,,"[""[NPM](https://www.npmjs.com/package/@avalanche-sdk/client)""]",SDK,TypeScript,"[""Wallet SDK"",""Crypto wallet integration"",""Avalanche""]","It is a dedicated library for creating, managing, and authenticating decentralized non-custodial wallets specifically on the Avalanche network",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
+avalanchejs,Ava Labs,,"[""[YARM](https://classic.yarnpkg.com/en/package/@avalanche-sdk/interchain)""]",SDK,TypeScript,"[""Web3 development"",""Blockchain framework"",""Avalanche""]","It is the classic Avalanche Platform JavaScript library for interfacing directly with the X-Chain, P-Chain, and C-Chain environments",Free,,$0,FALSE,FALSE,,TBD,TBD,TBD,TBD
 blockdaemon-sdk-free,,!offer:blockdaemon-sdk-free,,,,,,,,,,,,,,,
 blockdaemon-sdk-growth,,!offer:blockdaemon-sdk-growth,,,,,,,,,,,,,,,
 blockdaemon-sdk-starter,,!offer:blockdaemon-sdk-starter,,,,,,,,,,,,,,,

--- a/listings/specific-networks/lens/faucets.csv
+++ b/listings/specific-networks/lens/faucets.csv
@@ -1,4 +1,4 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,requiredMainnetBalance,price,starred,additionalNotes,dripLimitAmount,dripLimitPeriod,tag
 alchemy-testnet-faucet,Alchemy,,"[""[Get tokens](https://www.alchemy.com/faucets/lens-sepolia)""]",testnet,TRUE,TRUE,,$0,FALSE,,,,
-lenscan-testnet-faucet,Lens,Lenscan,"[""[Get tokens](https://testnet.lenscan.io/)""]",testnet,TRUE,TRUE,,$0,FALSE,,,,
+lenscan-testnet-faucet,Lens,,"[""[Get tokens](https://testnet.lenscan.io/)""]",testnet,TRUE,TRUE,,$0,FALSE,,,,
 thirdweb-testnet-faucet,Thirdweb,,"[""[Get tokens](https://thirdweb.com/faucets)""]",testnet,TRUE,TRUE,,$0,FALSE,,,,


### PR DESCRIPTION
Six listing rows carry plain-text `offer` values instead of canonical `!offer:<slug>` references (Avalanche sdks x4, Lens faucets, all-networks storages). Per DBIP #1955 these are indistinguishable from a missing canonical offer or a typo.

Blanks the invalid values; the paired validator rule PR (json-tools) blocks regressions.