### PR TITLE
fix(polygon): wormholescan-testnet chain (DBIP #1945)

### DIFF
--- a/listings/specific-networks/polygon/explorers.csv
+++ b/listings/specific-networks/polygon/explorers.csv
@@ -14,4 +14,4 @@ polygonscan-amoy,,!offer:polygonscan,"[""[Explorer](https://amoy.polygonscan.com
 polygonscan-mainnet,,!offer:polygonscan,,mainnet,,,,,,,,,,,
 tokenterminal-explorer-mainnet,,!offer:tokenterminal-explorer,"[""[Explore](https://tokenterminal.com/explorer/projects/polygon)""]",mainnet,,,,,,,,,,,
 wormholescan-mainnet,,!offer:wormholescan,"[""[Explore](https://wormholescan.io/)""]",mainnet,,,,,,,,,,,
-wormholescan-testnet,,!offer:wormholescan,"[""[Explore](https://wormholescan.io/?network=TESTNET)""]",testnet,,,,,,,,,,,
+wormholescan-testnet,,!offer:wormholescan,"[""[Explore](https://wormholescan.io/?network=TESTNET)""]",amoy,,,,,,,,,,,


### PR DESCRIPTION
DBIP #1945: chain-logo coverage for specific-network listings.

**Data:** listings/specific-networks/polygon/explorers.csv - singular outlier row wormholescan-testnet had chain=testnet while polygon's canonical testnet chain value and asset pair is amoy.png; changed to amoy. Every network folder now satisfies the documented one-PNG-per-unique-chain-value rule.

The world-chain/testnet.png gap mentioned in the DBIP was already fixed on current main.

**Companion tools PR:** Chain-Love/chain-love#2526

Reward address: 0x0920555F38a7dfB2b8417262be2b82f7bCbf019c