### PR TITLE
feat(validate): walletConnection enum + onChainWrite validation (DBIP #2466)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -1033,6 +1033,17 @@
     "cellType": null,
     "group": "capabilities"
   },
+  "walletConnection": {
+    "key": "walletConnection",
+    "label": "Wallet Connection",
+    "icon": "lucide:Wallet",
+    "description": "Whether normal use of the offer requires connecting an end-user wallet (none | optional | required | unknown).",
+    "filter": "select",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "capabilities"
+  },
   "agentSkills": {
     "key": "agentSkills",
     "label": "Agent Skills",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -327,6 +327,8 @@
       "additionalProperties": false,
       "properties": {
         "slug": { "type": "string" },
+        "walletConnection": { "type": ["string", "null"], "enum": ["none", "optional", "required", "unknown"] },
+        "onChainWrite": { "type": ["boolean", "null"] },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "toolType": { "type": "string" },
@@ -580,6 +582,7 @@
       "additionalProperties": false,
       "properties": {
         "slug": { "type": "string" },
+        "walletConnection": { "type": ["string", "null"], "enum": ["none", "optional", "required", "unknown"] },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "actionButtons": {
@@ -743,6 +746,8 @@
       "additionalProperties": false,
       "properties": {
         "slug": { "type": "string" },
+        "walletConnection": { "type": ["string", "null"], "enum": ["none", "optional", "required", "unknown"] },
+        "onChainWrite": { "type": ["boolean", "null"] },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "actionButtons": {

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -78,6 +78,29 @@ def rule_links_must_be_quoted(path: Path, rows: List[Dict[str, str]]) -> List[st
 
     return errors
 
+WALLET_CONNECTION_VALUES = {"", "none", "optional", "required", "unknown"}
+ON_CHAIN_WRITE_VALUES = {"", "TRUE", "FALSE"}
+
+
+def rule_wallet_metadata_enums(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    if not rows:
+        return []
+
+    errors: List[str] = []
+    for idx, row in enumerate(rows, start=2):
+        wc = (row.get("walletConnection") or "").strip()
+        if wc not in WALLET_CONNECTION_VALUES:
+            errors.append(
+                f"{path}: row {idx}: walletConnection invalid value '{wc}' (allowed: none | optional | required | unknown)"
+            )
+        oc = (row.get("onChainWrite") or "").strip()
+        if oc not in ON_CHAIN_WRITE_VALUES:
+            errors.append(
+                f"{path}: row {idx}: onChainWrite invalid value '{oc}' (allowed: TRUE | FALSE)"
+            )
+    return errors
+
+
 def iter_csv_files(root: Path) -> Iterator[Path]:
     for dirpath, _, filenames in os.walk(root):
         for name in sorted(filenames):
@@ -89,6 +112,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_wallet_metadata_enums)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
Implements the schema/tooling side of [DBIP #2466](https://github.com/Chain-Love/chain-love/issues/2466).

## Changes
- `tools/schema.json`: added `walletConnection` property (nullable enum `none | optional | required | unknown`) to `services`, `platforms`, `mcpservers` defs; added `onChainWrite` (nullable boolean) to `services` and `platforms` defs
- `tools/validate_csv.py`: new `rule_wallet_metadata_enums` — enforces walletConnection enum membership (empty allowed) and onChainWrite TRUE/FALSE boolean values
- `meta/columns.json`: `walletConnection` column definition (select filter, capabilities group)

Pair with data PR #2531 (base `main`).

Reward address: `0x0920555F38a7dfB2b8417262be2b82f7bCbf019c`