### PR TITLE
feat(schema): sourceUrls + lastVerifiedAt columns + validation (DBIP #1966)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -1262,5 +1262,27 @@
     "sorting": "string",
     "pinning": null,
     "cellType": null
+  },
+  "sourceUrls": {
+    "key": "sourceUrls",
+    "label": "Source URLs",
+    "icon": "lucide:Link2",
+    "description": "Canonical source URLs (1-3) used to verify this row: docs, pricing, or network-support pages.",
+    "filter": null,
+    "sorting": null,
+    "pinning": null,
+    "cellType": "tags",
+    "group": "verification"
+  },
+  "lastVerifiedAt": {
+    "key": "lastVerifiedAt",
+    "label": "Last Verified",
+    "icon": "lucide:CalendarCheck",
+    "description": "ISO date (YYYY-MM-DD) the row's key claims were last checked against source URLs.",
+    "filter": "date",
+    "sorting": "date",
+    "pinning": null,
+    "cellType": null,
+    "group": "verification"
   }
 }

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -33,6 +33,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -135,6 +137,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -190,6 +194,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -250,6 +256,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -326,6 +334,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -369,6 +379,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -411,6 +423,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -453,6 +467,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -515,6 +531,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -579,6 +597,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -644,6 +664,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -703,6 +725,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -742,6 +766,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -792,6 +818,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "provider": { "type": "string" },
         "offer": { "type": ["string", "null"] },
@@ -850,6 +878,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sourceUrls": { "type": ["array", "null"], "items": { "type": "string" } },
+        "lastVerifiedAt": { "type": ["string", "null"], "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "slug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "name": { "type": ["string", "null"] },

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -3,6 +3,7 @@ from typing import Iterator, Callable, List, Dict
 import os
 import csv
 import re
+import json
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
 
@@ -78,6 +79,43 @@ def rule_links_must_be_quoted(path: Path, rows: List[Dict[str, str]]) -> List[st
 
     return errors
 
+def rule_source_urls(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    if not rows:
+        return []
+
+    errors: List[str] = []
+    for idx, row in enumerate(rows, start=2):
+        su = (row.get("sourceUrls") or "").strip()
+        if su:
+            try:
+                parsed = json.loads(su)
+            except Exception:
+                errors.append(
+                    f"{path}: row {idx}: sourceUrls must be a JSON array of URL strings, got '{su[:60]}'"
+                )
+                continue
+            if not isinstance(parsed, list) or not parsed:
+                errors.append(
+                    f"{path}: row {idx}: sourceUrls must be a non-empty JSON array, got '{su[:60]}'"
+                )
+            elif len(parsed) > 3:
+                errors.append(
+                    f"{path}: row {idx}: sourceUrls limited to 1-3 URLs, got {len(parsed)}"
+                )
+            else:
+                for u in parsed:
+                    if not (isinstance(u, str) and (u.startswith("http://") or u.startswith("https://"))):
+                        errors.append(
+                            f"{path}: row {idx}: sourceUrls entry '{u}' is not an http(s) URL"
+                        )
+        lv = (row.get("lastVerifiedAt") or "").strip()
+        if lv:
+            if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", lv):
+                errors.append(
+                    f"{path}: row {idx}: lastVerifiedAt '{lv}' must be YYYY-MM-DD"
+                )
+    return errors
+
 def iter_csv_files(root: Path) -> Iterator[Path]:
     for dirpath, _, filenames in os.walk(root):
         for name in sorted(filenames):
@@ -89,6 +127,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_source_urls)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
Implements the schema/tools side of [DBIP #1966](https://github.com/Chain-Love/chain-love/issues/1966).

## Changes
- `tools/schema.json`: `sourceUrls` (string-array | null) + `lastVerifiedAt` (string | null, `^\\d{4}-\\d{2}-\\d{2}$`) added as optional properties on all 15 offer category defs (`apis`, `explorers`, `oracles`, `bridges`, `services`, `storages`, `faucets`, `analytics`, `wallets`, `mcpservers`, `sdks`, `ramps`, `platforms`, `security`, `agents`)
- `tools/validate_csv.py`: `rule_source_urls` — validates sourceUrls is a JSON array of 1-3 http(s) URL strings (blank allowed) and lastVerifiedAt matches YYYY-MM-DD (blank allowed)
- `meta/columns.json`: both column definitions (verification group)

Verified locally: validate_csv passes, full generate+validate pipeline exit 0, negative test (bad date format) correctly rejected.

Companion data PR: `dbip-1966-source-metadata` (#2533)

Reward address: `0x0920555F38a7dfB2b8417262be2b82f7bCcbf019c`