### PR TITLE
Add wallet recovery metadata schema

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,26 +1,33 @@
-name: "Validate JSON"
+name: "Validate JSON tooling"
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
-  validate:
+  validate-tools:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      
+
       - name: Install dependencies
-        run: pip install --upgrade pip && pip install -r requirements.txt
+        run: python -m pip install --upgrade pip && python -m pip install -r tools/requirements.txt
 
-      - name: Run CSV to JSON
-        run: python3 csv_to_json.py
+      - name: Check Python tooling
+        run: python -m compileall -q tools
 
-      - name: Run validation script
-        run: python validate.py
+      - name: Check JSON files
+        run: |
+          python -m json.tool tools/schema.json > /dev/null
+          python -m json.tool meta/columns.json > /dev/null
+
+      - name: Run focused schema tests
+        run: python tools/test_wallet_recovery_metadata.py

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ This guide explains how to **add new categories and columns for the Chain.Love p
 Data files are not documented in detail in this guide. Their structure and contribution flow are described in the `main` branch README: [README.md](https://github.com/Chain-Love/chain-love/blob/main/README.md).  
 However, schema/meta changes in this branch must be mirrored in data tables on `main` (for example when adding/removing categories or columns).
 
+### Wallet recovery metadata
+
+`wallets.recoveryMethods` is an optional JSON array containing only officially
+documented recovery mechanisms: `seed_phrase`, `cloud_backup`,
+`social_guardians`, `multisig`, `passkey`, `hardware_backup`,
+`provider_assisted`, `none`, or `unknown`. Use `unknown` for unreviewed
+migration rows, and do not infer `seed_phrase` from `keyExport`. `none` is
+exclusive and cannot be combined with another method.
+
+`wallets.recoveryDelay` records the minimum documented product- or
+protocol-enforced waiting period before recovery can finalize. It must be `0`,
+a duration such as `24h`/`3d`, or blank/null when not applicable or
+undocumented. Do not use customer-support response time as a recovery delay.
+
 ---
 
 ## 1. Files and responsibilities
@@ -565,4 +579,3 @@ When asked to **remove a column**, an agent should:
   - Edit `tools/schema.json`: remove the column from every `$defs.<category>` where it appears.
   - Remove its entry from `meta/columns.json`.
   - On `main`, remove the column from every affected category CSV (see **§5**).
-

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -747,6 +747,28 @@
     "cellType": null,
     "group": "security"
   },
+  "recoveryMethods": {
+    "key": "recoveryMethods",
+    "label": "Recovery Methods",
+    "icon": "lucide:ShieldCheck",
+    "description": "Officially documented wallet access recovery mechanisms. unknown is for unreviewed migration rows; none is exclusive.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "security"
+  },
+  "recoveryDelay": {
+    "key": "recoveryDelay",
+    "label": "Recovery Delay",
+    "icon": "lucide:TimerReset",
+    "description": "Minimum documented product- or protocol-enforced waiting period before recovery can finalize.",
+    "filter": "select",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "security"
+  },
   "native": {
     "key": "native",
     "label": "Native",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -528,6 +528,36 @@
         "msig": { "type": "boolean" },
         "hardware": { "type": "boolean" },
         "keyExport": { "type": "boolean" },
+        "recoveryMethods": {
+          "type": ["array", "null"],
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "seed_phrase",
+              "cloud_backup",
+              "social_guardians",
+              "multisig",
+              "passkey",
+              "hardware_backup",
+              "provider_assisted",
+              "none",
+              "unknown"
+            ]
+          },
+          "not": {
+            "type": "array",
+            "minItems": 2,
+            "contains": { "const": "none" }
+          },
+          "description": "Officially documented mechanisms for restoring wallet access after loss of a device, key, or authentication credential. unknown is for unreviewed migration rows; none is exclusive."
+        },
+        "recoveryDelay": {
+          "type": ["string", "null"],
+          "pattern": "^(0|[1-9][0-9]*(m|h|d))$",
+          "description": "Minimum documented product- or protocol-enforced waiting period before recovery can finalize. Use null when not applicable or undocumented."
+        },
         "native": { "type": "boolean" },
         "evm": { "type": "boolean" },
         "tendermint": { "type": "boolean" },

--- a/tools/test_wallet_recovery_metadata.py
+++ b/tools/test_wallet_recovery_metadata.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Focused checks for wallet recovery metadata schema additions."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = json.loads(Path("tools/schema.json").read_text(encoding="utf-8"))
+VALIDATOR = Draft202012Validator(SCHEMA["$defs"]["wallets"])
+
+
+BASE_WALLET = {
+    "slug": "example-wallet",
+    "provider": "Example",
+    "offer": None,
+    "openSource": False,
+    "supportedPlatforms": ["Web"],
+    "custodial": False,
+    "mfa": False,
+    "msig": False,
+    "hardware": False,
+    "keyExport": True,
+    "native": False,
+    "evm": True,
+    "tendermint": False,
+    "tokensSupport": ["ERC-20"],
+    "staking": False,
+    "price": None,
+    "support": None,
+    "audit": None,
+    "languages": None,
+    "starred": False,
+    "actionButtons": ["[Website](https://example.com)"],
+    "tag": None,
+}
+
+
+def assert_valid(**updates: object) -> None:
+    wallet = copy.deepcopy(BASE_WALLET)
+    wallet.update(updates)
+    errors = sorted(VALIDATOR.iter_errors(wallet), key=lambda error: error.path)
+    assert not errors, [error.message for error in errors]
+
+
+def assert_invalid(**updates: object) -> None:
+    wallet = copy.deepcopy(BASE_WALLET)
+    wallet.update(updates)
+    errors = list(VALIDATOR.iter_errors(wallet))
+    assert errors, "expected schema validation to fail"
+
+
+def test_recovery_methods_accept_known_enum_values() -> None:
+    assert_valid(recoveryMethods=["seed_phrase"], recoveryDelay="0")
+    assert_valid(
+        recoveryMethods=["passkey", "social_guardians"],
+        recoveryDelay="48h",
+    )
+    assert_valid(recoveryMethods=["multisig", "hardware_backup"], recoveryDelay=None)
+    assert_valid(recoveryMethods=["unknown"], recoveryDelay=None)
+
+
+def test_recovery_methods_reject_unknown_values_duplicates_and_none_combos() -> None:
+    assert_invalid(recoveryMethods=["mnemonic"], recoveryDelay=None)
+    assert_invalid(recoveryMethods=["seed_phrase", "seed_phrase"], recoveryDelay=None)
+    assert_invalid(recoveryMethods=["none", "seed_phrase"], recoveryDelay=None)
+
+
+def test_recovery_delay_format() -> None:
+    assert_valid(recoveryMethods=["seed_phrase"], recoveryDelay="1m")
+    assert_valid(recoveryMethods=["seed_phrase"], recoveryDelay="24h")
+    assert_valid(recoveryMethods=["seed_phrase"], recoveryDelay="7d")
+    assert_invalid(recoveryMethods=["seed_phrase"], recoveryDelay="01h")
+    assert_invalid(recoveryMethods=["seed_phrase"], recoveryDelay="2w")
+    assert_invalid(recoveryMethods=["seed_phrase"], recoveryDelay="fast")
+
+
+if __name__ == "__main__":
+    test_recovery_methods_accept_known_enum_values()
+    test_recovery_methods_reject_unknown_values_duplicates_and_none_combos()
+    test_recovery_delay_format()


### PR DESCRIPTION
## Summary

Implements the schema/tooling half of Chain-Love DBIP #2025 by adding normalized wallet recovery metadata:

- `wallets.recoveryMethods`: documented recovery mechanisms with enum validation, uniqueness, and exclusive `none` handling.
- `wallets.recoveryDelay`: documented recovery waiting periods with `0`, `m`, `h`, or `d` duration validation.
- UI metadata for both columns in `meta/columns.json`.
- `json-tools` README guidance for migration semantics and non-inference from `keyExport`.
- Focused schema tests for accepted enum values, invalid values, duplicates, `none` combinations, and duration format.

This PR also updates the `json-tools` validation workflow to run against the branch layout that actually exists here (`tools/requirements.txt`, `tools/schema.json`, `meta/columns.json`, and focused tests). The data half is in a separate `main` PR.

## Validation

- `python -m compileall -q tools`
- `python -m json.tool tools/schema.json > /dev/null`
- `python -m json.tool meta/columns.json > /dev/null`
- `python tools/test_wallet_recovery_metadata.py`
- Combined local validation with the paired data branch: `python tools/csv_to_json.py && python tools/validate.py` passed; only pre-existing warnings appeared for `lightning`, `camino`, and `zilliqa` all-networks analytics/apis chain values.

## Notes

Issue #2025 includes the DBIP author's reward address. I posted a clarification comment asking whether separate implementer compensation is intended; this PR is the scoped implementation path for maintainer review.
