### PR TITLE
feat(faucets): add normalized claim requirements schema

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -626,6 +626,17 @@
     "cellType": null,
     "group": "accessAndLimits"
   },
+  "claimRequirements": {
+    "key": "claimRequirements",
+    "label": "Claim Requirements",
+    "icon": "lucide:ListChecks",
+    "description": "Extra actions or eligibility checks required to claim faucet tokens.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": null,
+    "group": "accessAndLimits"
+  },
   "dripLimitAmount": {
     "key": "dripLimitAmount",
     "label": "Drip Limit Amount",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -418,6 +418,23 @@
         "requiresLogin": { "type": "boolean" },
         "hasCaptcha": { "type": "boolean" },
         "requiredMainnetBalance": { "type": ["string", "null"] },
+        "claimRequirements": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "string",
+            "enum": [
+              "wallet_connection",
+              "social_post",
+              "api_key",
+              "transaction_history",
+              "proof_of_work",
+              "email_verification",
+              "community_membership",
+              "identity_verification"
+            ]
+          },
+          "uniqueItems": true
+        },
         "price": { "type": ["string", "null"] },
         "dripLimitAmount": { "type": ["string", "null"] },
         "dripLimitPeriod": { "type": ["string", "null"] },


### PR DESCRIPTION
## Summary

- add optional `claimRequirements` metadata to the faucet JSON schema
- restrict values to the eight normalized requirements proposed in #2547
- reject duplicate entries through `uniqueItems`
- expose the field as a searchable multi-select in column metadata

## Compatibility

The property is intentionally optional. Existing generated JSON remains valid while faucet rows are backfilled incrementally, and `NULL` remains distinct from an explicit empty array.

## Validation

Tested against the paired data branch:

- CSV-to-JSON generation completed for 155 network files
- 29 hydrated faucet rows inherited populated requirements
- every populated value matched the schema enum
- no duplicate array items were present
- schema and metadata JSON parsed successfully

The existing generation warnings for Camino, Lightning, and Zilliqa are unrelated to this change. GitHub CI remains authoritative for the complete repository JSON Schema run.

Related proposal: #2547

Paired data PR: #2549

Reward address (Ethereum Mainnet USDC/USDT): `0x2e81bcf6435c98704434f4489aad54fd84166c76`

## AI disclosure

Implemented and validated with Codex assistance. The focused checks and paired generation results above were run locally; no human-only verification claim is being made.