### PR TITLE
Add official AlgoKit links for Algorand

### DIFF
--- a/listings/specific-networks/algorand/platforms.csv
+++ b/listings/specific-networks/algorand/platforms.csv
@@ -1,4 +1,4 @@
 slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
-algokit,,!offer:algokit,,,,,,,,,,
+algokit,,!offer:algokit,"[""[Website](https://algorand.co/algokit)"",""[Docs](https://dev.algorand.co/algokit/algokit-intro/)""]",,,,,,,,,
 portal-developer,,!offer:portal-developer,,,,,,,,,,
 portal-startup,,!offer:portal-startup,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add the official AlgoKit website and documentation links to the existing Algorand platform listing.

## Type of change
- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: algorand
- Categories affected: platforms

This updates one existing listing and does not add a provider or offer.

## Links
- https://algorand.co/algokit
- https://dev.algorand.co/algokit/algokit-intro/

## Validation checklist
- [x] Followed the Style Guide and Column Definitions.
- [x] Personally opened and verified every new link.
- [x] Confirmed that AlgoKit is the official Algorand developer platform and that the values are correct.
- [x] This is a reviewed, source-backed data contribution rather than an unverified submission.

## Rewards

Rewards address: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`
