### PR TITLE
Add official Filecoin platform links

### DIFF
--- a/listings/specific-networks/filecoin/platforms.csv
+++ b/listings/specific-networks/filecoin/platforms.csv
@@ -1,7 +1,7 @@
 slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
-4everland-free,,!offer:4everland-free,,,,,,,,,,
-4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,,,,,,,,,,
-apeworx,,!offer:apeworx,,,,,,,,,,
+4everland-free,,!offer:4everland-free,"[""[Website](https://www.4everland.org/)""]",,,,,,,,,
+4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,"[""[Docs](https://docs.4everland.org/get-started/billing-and-pricing/pricing-model)""]",,,,,,,,,
+apeworx,,!offer:apeworx,"[""[Docs](https://docs.apeworx.io/)""]",,,,,,,,,
 portal-developer,,!offer:portal-developer,,,,,,,,,,
 portal-startup,,!offer:portal-startup,,,,,,,,,,
 spheron-network,,!offer:spheron-network,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add verified official links to three existing Filecoin platform listings: 4EVERLAND Free, 4EVERLAND Pay-As-You-Go, and ApeWorX.

## Type of change
- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: filecoin
- Categories affected: platforms

This updates existing listings and does not add providers or offers.

## Links
- https://www.4everland.org/
- https://docs.4everland.org/get-started/billing-and-pricing/pricing-model
- https://docs.apeworx.io/

## Validation checklist
- [x] Followed the Style Guide and Column Definitions.
- [x] Personally opened and verified every new link.
- [x] Confirmed that the links are official provider website/documentation links and that the existing listings are for Filecoin.
- [x] This is a reviewed, source-backed data contribution rather than an unverified submission.

## Rewards

Rewards address: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`
