### PR TITLE
Add official Filecoin MCP server links

### DIFF
--- a/listings/specific-networks/filecoin/mcpservers.csv
+++ b/listings/specific-networks/filecoin/mcpservers.csv
@@ -1,5 +1,5 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
-blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
-coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,,,,,
-evm-mcp-server,,!offer:evm-mcp-server,,,,,,,,,,,,,,,,,,,,
-wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,,,,,
+blockscout-mcp,,!offer:blockscout-mcp,"[""[Website](https://github.com/blockscout/mcp-server)"",""[Docs](https://github.com/blockscout/mcp-server#readme)""]",,,,,,,,,,,,,,,,,,,
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,"[""[Website](https://github.com/coinbase/agentkit/tree/main/typescript/framework-extensions/model-context-protocol)"",""[Docs](https://docs.cdp.coinbase.com/agent-kit/core-concepts/model-context-protocol)""]",,,,,,,,,,,,,,,,,,,
+evm-mcp-server,,!offer:evm-mcp-server,"[""[Website](https://github.com/mcpdotdirect/evm-mcp-server)"",""[Docs](https://github.com/mcpdotdirect/evm-mcp-server#readme)""]",,,,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,"[""[Website](https://github.com/wallet-agent/wallet-agent)"",""[Docs](https://github.com/wallet-agent/wallet-agent#readme)""]",,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Populate the four blank `actionButtons` cells in the Filecoin-specific MCP server listings using the canonical action buttons already present in `references/offers/mcpservers.csv`.

## Scope

- `listings/specific-networks/filecoin/mcpservers.csv`
- 4 existing rows updated
- No rows, offers, providers, or non-action fields changed

## Validation

- CSV parses at 23 columns per row
- Slug ordering unchanged
- `git diff --check` passes
- All eight added HTTPS destinations returned successfully with `curl`

## Rewards

Estimated at the published $0.06 per improved non-null cell: 4 cells / $0.24 before review adjustments.

Rewards address: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`