### PR TITLE
Add official Somnia MCP server links

### DIFF
--- a/listings/specific-networks/somnia/mcpservers.csv
+++ b/listings/specific-networks/somnia/mcpservers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
-coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,,,,,
-wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,,,,,
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,"[""[Website](https://github.com/coinbase/agentkit/tree/main/typescript/framework-extensions/model-context-protocol)"",""[Docs](https://docs.cdp.coinbase.com/agent-kit/core-concepts/model-context-protocol)""]",,,,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,"[""[Website](https://github.com/wallet-agent/wallet-agent)"",""[Docs](https://github.com/wallet-agent/wallet-agent#readme)""]",,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Populate the two blank `actionButtons` cells in the Somnia-specific MCP server listings using the canonical action buttons already present in `references/offers/mcpservers.csv`.

## Scope

- `listings/specific-networks/somnia/mcpservers.csv`
- 2 existing rows updated
- No rows, offers, providers, or non-action fields changed

## Validation

- CSV parses at 23 columns per row
- `git diff --check` passes
- All four added HTTPS destinations returned successfully with `curl`

## Rewards

Estimated at the published $0.06 per improved non-null cell: 2 cells / $0.12 before review adjustments.

Rewards address: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`