### PR TITLE
data: document ChainSafe Filecoin faucet limits

### DIFF
--- a/listings/specific-networks/filecoin/faucets.csv
+++ b/listings/specific-networks/filecoin/faucets.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,price,starred,requiredMainnetBalance,dripLimitAmount,dripLimitPeriod,additionalNotes,tag
 beryx-faucet,Beryx,,"[""[Get tokens](https://beryx.io/faucet)""]",calibnet,FALSE,FALSE,$0,FALSE,,,,,
-chainsafe-faucet,ChainSafe,,"[""[Get tokens](https://faucet.calibnet.chainsafe-fil.io/funds.html)""]",calibnet,FALSE,FALSE,$0,FALSE,,,,,
+chainsafe-faucet,ChainSafe,,"[""[Get tokens](https://faucet.calibnet.chainsafe-fil.io/funds.html)""]",calibnet,FALSE,FALSE,$0,FALSE,,100 tFIL,,"[""Not dispensing real Filecoin tokens""]",


### PR DESCRIPTION
## Summary

- Add the documented 100 tFIL dispense amount to the ChainSafe Filecoin Calibration faucet listing.
- Note that the faucet does not dispense real Filecoin tokens.
- 2 improved non-null cells total.

## Sources

- https://faucet.calibnet.chainsafe-fil.io/funds.html
- https://faucet.calibnet.chainsafe-fil.io/
- Grant terms: https://github.com/Chain-Love/chain-love/discussions/41

## Validation

- CSV parsed successfully with 14 columns.
- Semantic diff confirms only `dripLimitAmount` and `additionalNotes` changed on `chainsafe-faucet`.
- `git diff --check` passed.

## Grant payout

Ethereum mainnet address: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`