### PR TITLE
data: document PublicNode Somnia RPC endpoint

### DIFF
--- a/listings/specific-networks/somnia/apis.csv
+++ b/listings/specific-networks/somnia/apis.csv
@@ -28,7 +28,7 @@ ormi-mainnet-pay-as-you-go-indexer,,!offer:ormi-pay-as-you-go-indexer,"[""[Buy](
 ormi-testnet-enterprise-indexer,,!offer:ormi-enterprise-indexer,"[""[Contact](https://calendly.com/ormilabs)"",""[Docs](https://docs.ormilabs.com/dedicated-env/somnia/subgraphs/overview#supported-networks)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
 ormi-testnet-free-indexer,,!offer:ormi-free-indexer,"[""[Website](https://ormilabs.com/chain-list/somnia/)"",""[Docs](https://docs.ormilabs.com/dedicated-env/somnia/subgraphs/overview#supported-networks)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
 ormi-testnet-pay-as-you-go-indexer,,!offer:ormi-pay-as-you-go-indexer,"[""[Buy](https://ormilabs.com/pricing)"",""[Docs](https://docs.ormilabs.com/dedicated-env/somnia/subgraphs/overview#supported-networks)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
-publicnode-mainnet-public-recent-state,,!offer:publicnode-public-recent-state,"[""[Website](https://somnia.publicnode.com/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+publicnode-mainnet-public-recent-state,,!offer:publicnode-public-recent-state,"[""[Website](https://somnia.publicnode.com/)""]",,,,RPC,EVM JSON-RPC,mainnet,,,,,,,,,,,https://somnia-rpc.publicnode.com,,,,,,,,
 somnia-mainnet-free-recent-state,,!offer:somnia-free-recent-state,,,,,,,mainnet,,,TRUE,,,,,,,,,,,,,,,,
 somnia-testnet-free-recent-state,,!offer:somnia-free-recent-state,,,,,,,testnet,,,,,,,,,,,,,,,,,,,
 stakely-mainnet-dedicated-full-archive,,!offer:stakely-dedicated-full-archive,"[""[Buy](https://app.stakely.io/naas)"",""[Docs](https://docs.somnia.network/developer/deployment-and-production/ecosystem/ecosystem-tools/rpc)""]",,,,,EVM JSON-RPC,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

- Document the verified PublicNode Somnia mainnet JSON-RPC endpoint on the existing listing.
- Classify the offer as RPC / EVM JSON-RPC and populate its endpoint address.
- Three existing non-null cells improved; no rows, providers, offers, or schemas added.

## Sources and verification

- Official Somnia RPC guidance: https://docs.somnia.network/developer/deployment-and-production/ecosystem/ecosystem-tools/rpc
- PublicNode endpoint: https://somnia-rpc.publicnode.com/
- A read-only `eth_chainId` request returned `0x13a7` (5031), matching Somnia mainnet.
- Grant terms: https://github.com/Chain-Love/chain-love/discussions/41

## Validation

- Full repository pre-commit validation passed.
- CSV shape verified: 29 columns on the changed row.
- `git diff --check` passed.

## Grant payout

Ethereum mainnet address: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`

Estimated grant at the current 0.06 USDC per improved cell rate: 0.18 USDC gross.