### PR TITLE
feat(tools): allow storage trial metadata (DBIP #2561)

### DIFF
--- a/tools/schema.json
+++ b/tools/schema.json
@@ -374,6 +374,7 @@
         "offer": { "type": ["string", "null"] },
         "toolType": { "type": "string" },
         "price": { "type": ["string", "null"] },
+        "trial": { "type": "boolean" },
         "tag": { "type": ["array", "null"], "items": { "type": "string" } },
         "description": { "type": ["string", "null"] },
         "starred": { "type": "boolean" },


### PR DESCRIPTION
## Summary

Companion schema change for [DBIP #2561](https://github.com/Chain-Love/chain-love/issues/2561).

## Changes
- Adds optional boolean `trial` metadata to the `storages` definition in `tools/schema.json`.
- Keeps the field optional so existing direct listing rows remain valid while canonical `!offer` rows hydrate the new value.

The matching data PR targets `main`: `feat(data): add storage offer trial metadata (DBIP #2561)`

## Validation
- JSON schema parses successfully.
- Full generation and schema/rule validation passed in an isolated checkout.

## Rewards
Rewards address: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`

This is an AI-assisted, source-checked contribution; it is not a blind generated submission.