### PR TITLE
feat(tools): add storage trial schema (DBIP #2561)

### DIFF
--- a/tools/schema.json
+++ b/tools/schema.json
@@ -377,6 +377,7 @@
         "tag": { "type": ["array", "null"], "items": { "type": "string" } },
         "description": { "type": ["string", "null"] },
         "starred": { "type": "boolean" },
+        "trial": { "type": "boolean" },
         "actionButtons": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -402,6 +403,7 @@
         "tag",
         "description",
         "starred",
+        "trial",
         "actionButtons",
         "planType"
       ]


### PR DESCRIPTION
Implements the schema side of DBIP #2561.

Changes:
- Adds the `trial` boolean property to the `storages` schema.
- Marks `trial` as required, matching the existing trial fields in related offer categories.
- The shared `trial` metadata already exists in `meta/columns.json`.

The paired data PR is being submitted against `main` as `feat(data): add storage trial flags`.

Validation: the paired data and schema state passes CSV validation, JSON generation, JSON Schema validation, and repository rules locally. Existing warnings about legacy networks with no chain values remain unchanged.

Reward address (Ethereum Mainnet USDC/USDT): `0xEf4684F19440f8c1E460fC0c608cA7D3A1b7A661`
