### PR TITLE
Update schedule for build and release workflow

### DIFF
--- a/.github/workflows/build-and-relese-json.yaml
+++ b/.github/workflows/build-and-relese-json.yaml
@@ -1,11 +1,8 @@
 name: Build & Release JSON
 
 on:
-  push:
-    branches:
-      - main
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "12 12 * * MON"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This remove launch on every push, and instead creates schedule to once a week (which is more than enough in my eyes)