### PR TITLE
feat(schema): normalize API authentication methods (DBIP #2471)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -131,6 +131,17 @@
     "cellType": null,
     "group": "serviceDetails"
   },
+  "authenticationMethods": {
+    "key": "authenticationMethods",
+    "label": "Authentication Methods",
+    "icon": "lucide:KeyRound",
+    "description": "Credential or authentication methods supported or required for API access.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "accessAndLimits"
+  },
   "regions": {
     "key": "regions",
     "label": "Regions",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -90,6 +90,30 @@
           "type": "string",
           "examples": ["EVM JSON-RPC", "The Graph"]
         },
+        "authenticationMethods": {
+          "description": "Credential or authentication methods supported or required for API access. Null means the method has not been verified; credentials and secrets must never be stored here.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string",
+            "enum": [
+              "none",
+              "api_key",
+              "bearer_token",
+              "jwt",
+              "basic_auth",
+              "oauth2",
+              "mtls",
+              "wallet_signature"
+            ]
+          },
+          "uniqueItems": true,
+          "not": {
+            "allOf": [
+              { "type": "array", "contains": { "const": "none" } },
+              { "type": "array", "minItems": 2 }
+            ]
+          }
+        },
         "additionalFeatures": {
           "type": ["array", "null"],
           "items": { "type": "string" }

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Iterator, Callable, List, Dict
 import os
 import csv
+import json
 import re
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
@@ -84,11 +85,84 @@ def iter_csv_files(root: Path) -> Iterator[Path]:
             if name.lower().endswith(".csv"):
                 yield Path(dirpath) / name
 
+
+AUTHENTICATION_METHODS = {
+    "none",
+    "api_key",
+    "bearer_token",
+    "jwt",
+    "basic_auth",
+    "oauth2",
+    "mtls",
+    "wallet_signature",
+}
+
+
+def rule_authenticationMethods(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    """Validate DBIP #2471 authenticationMethods values in API CSVs."""
+    errors: List[str] = []
+    if not rows or "authenticationMethods" not in rows[0]:
+        return errors
+
+    for idx, row in enumerate(rows, start=2):
+        raw = (row.get("authenticationMethods") or "").strip()
+        if not raw or raw.lower() == "null":
+            continue
+
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError:
+            errors.append(
+                f"{path}: row {idx}: slug '{row.get('slug', '')}': "
+                "authenticationMethods is not valid JSON"
+            )
+            continue
+
+        if not isinstance(value, list):
+            errors.append(
+                f"{path}: row {idx}: slug '{row.get('slug', '')}': "
+                "authenticationMethods must be a JSON array or null"
+            )
+            continue
+
+        invalid = [
+            item
+            for item in value
+            if not isinstance(item, str) or item not in AUTHENTICATION_METHODS
+        ]
+        if invalid:
+            errors.append(
+                f"{path}: row {idx}: slug '{row.get('slug', '')}': "
+                f"authenticationMethods contains unsupported values {invalid}"
+            )
+
+        seen = []
+        duplicates = False
+        for item in value:
+            if item in seen:
+                duplicates = True
+                break
+            seen.append(item)
+        if duplicates:
+            errors.append(
+                f"{path}: row {idx}: slug '{row.get('slug', '')}': "
+                "authenticationMethods must not contain duplicates"
+            )
+
+        if "none" in value and len(value) > 1:
+            errors.append(
+                f"{path}: row {idx}: slug '{row.get('slug', '')}': "
+                "'none' cannot be combined with another authentication method"
+            )
+
+    return errors
+
 def main():
     root = Path(".")
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_authenticationMethods)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

Implements the schema/tooling side of DBIP #2471.

- Adds optional `authenticationMethods` to the generated API schema.
- Restricts values to `none`, `api_key`, `bearer_token`, `jwt`, `basic_auth`, `oauth2`, `mtls`, and `wallet_signature`.
- Rejects duplicate values and rejects `none` when combined with another method.
- Adds a CSV validator rule with the same checks.
- Adds searchable column metadata.
- Documents null semantics and the no-secrets rule in the schema description.

The paired data PR is #2602.

## Validation

- `python3 -m json.tool tools/schema.json`
- `python3 -m py_compile tools/validate_csv.py`
- Positive and negative JSON Schema cases for null, empty, single-method, multi-method, mixed `none`, duplicates, and unknown values.
- Positive and negative CSV validator cases, including malformed JSON and non-string values.
- `python3 tools/validate_csv.py`

Related DBIP: #2471

Reward address (Ethereum Mainnet USDC/USDT): `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`

## AI disclosure

Implemented and validated with Codex assistance.