### PR TITLE
feat(schema): normalize oracle update models (DBIP #2552)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -131,6 +131,17 @@
     "cellType": null,
     "group": "serviceDetails"
   },
+  "updateModels": {
+    "key": "updateModels",
+    "label": "Update Models",
+    "icon": "lucide:RefreshCw",
+    "description": "Documented mechanisms by which an oracle makes fresh data available: push, pull, or request-response. Null means unverified.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
   "regions": {
     "key": "regions",
     "label": "Regions",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -195,6 +195,12 @@
         "offer": { "type": ["string", "null"] },
         "chain": { "type": "string" },
         "technology": { "type": "string" },
+        "updateModels": {
+          "type": ["array", "null"],
+          "items": { "type": "string", "enum": ["push", "pull", "request-response"] },
+          "uniqueItems": true,
+          "description": "Documented mechanisms by which the oracle makes fresh data available: push, pull, or request-response. Null means unverified."
+        },
         "starred": { "type": "boolean" },
         "availableApis": {
           "type": ["array", "null"],

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -2,9 +2,11 @@ from pathlib import Path
 from typing import Iterator, Callable, List, Dict
 import os
 import csv
+import json
 import re
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
+UPDATE_MODELS = {"push", "pull", "request-response"}
 
 Rule = Callable[[Path, List[Dict[str, str]]], List[str]]
 
@@ -50,6 +52,42 @@ def rule_slug_sorted(path: Path, rows: List[Dict[str, str]]) -> List[str]:
 
     return errors
 
+def rule_update_models(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    errors: List[str] = []
+
+    for idx, row in enumerate(rows, start=2):
+        raw = row.get("updateModels", "")
+        if raw is None or raw.strip() == "" or raw.strip().lower() == "null":
+            continue
+
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            errors.append(f"{path}: row {idx}: updateModels must be valid JSON: {exc.msg}")
+            continue
+
+        if value is None:
+            continue
+        if not isinstance(value, list):
+            errors.append(f"{path}: row {idx}: updateModels must be a JSON array or null")
+            continue
+
+        seen = set()
+        for item in value:
+            if not isinstance(item, str):
+                errors.append(f"{path}: row {idx}: updateModels values must be strings")
+                continue
+            if item not in UPDATE_MODELS:
+                errors.append(
+                    f"{path}: row {idx}: unsupported updateModels value '{item}' "
+                    f"(allowed: {', '.join(sorted(UPDATE_MODELS))})"
+                )
+            if item in seen:
+                errors.append(f"{path}: row {idx}: duplicate updateModels value '{item}'")
+            seen.add(item)
+
+    return errors
+
 def looks_like_url(v: str) -> bool:
     return v.startswith("http://") or v.startswith("https://")
 
@@ -89,6 +127,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_update_models)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

Implements the schema and tooling side of [DBIP #2552](https://github.com/Chain-Love/chain-love/issues/2552).

- Adds optional nullable `updateModels` to the oracle schema.
- Restricts values to `push`, `pull`, and `request-response`.
- Rejects duplicates and malformed, non-array, non-string, or unsupported values in the CSV validator.
- Adds searchable column metadata with null meaning unverified.

The paired data PR targets `main`: [#2605](https://github.com/Chain-Love/chain-love/pull/2605). It populates three source-backed examples.

## Validation

- `python3 -m json.tool tools/schema.json`
- `python3 -m json.tool meta/columns.json`
- `python3 -m py_compile tools/validate_csv.py`
- Positive and negative JSON Schema cases for null, empty arrays, valid enum values, duplicates, and unsupported values.
- Positive and negative CSV validator cases for malformed JSON, non-arrays, non-strings, duplicates, and unsupported values.
- `python3 tools/validate_csv.py`
- Paired data/tools generation and full JSON Schema/rules validation passed.

## Reward destination

Ethereum Mainnet USDC/USDT: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`

## AI disclosure

Implemented and validated with Codex assistance; no secrets or provider credentials are included.