### PR TITLE
feat(schema): resolve canonical provider slugs in JSON tooling (DBIP #2604)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This guide explains how to **add new categories and columns for the Chain.Love p
 Data files are not documented in detail in this guide. Their structure and contribution flow are described in the `main` branch README: [README.md](https://github.com/Chain-Love/chain-love/blob/main/README.md).  
 However, schema/meta changes in this branch must be mirrored in data tables on `main` (for example when adding/removing categories or columns).
 
+Canonical offer tables on `main` use `providerSlug` to reference the exact
+provider registry slug. The generator resolves that value to the existing
+human-readable `provider` field in generated JSON and retains `providerSlug`
+as an additive compatibility-safe field; consumers should migrate joins to
+the slug while treating `provider` as display metadata.
+
 ---
 
 ## 1. Files and responsibilities
@@ -565,4 +571,3 @@ When asked to **remove a column**, an agent should:
   - Edit `tools/schema.json`: remove the column from every `$defs.<category>` where it appears.
   - Remove its entry from `meta/columns.json`.
   - On `main`, remove the column from every affected category CSV (see **§5**).
-

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -32,6 +32,17 @@
     "cellType": "provider",
     "group": "identity"
   },
+  "providerSlug": {
+    "key": "providerSlug",
+    "label": "Provider Slug",
+    "icon": "lucide:Fingerprint",
+    "description": "Stable provider identifier used for machine-readable joins.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "identity"
+  },
   "actionButtons": {
     "key": "actionButtons",
     "label": "Actions",

--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -452,10 +452,10 @@ def resolve_offers(
                 # Base = offer row
                 merged = dict(offer_row)
 
-                # Listing overrides non-empty fields (except offer itself)
+                # Listing overrides non-empty fields (except canonical identity fields)
                 for k, v in item.items():
-                    if k == "offer":
-                        continue  # never override final offer value
+                    if k in ("offer", "provider", "providerSlug"):
+                        continue  # preserve the canonical offer identity
 
                     if v is None:
                         continue
@@ -532,6 +532,44 @@ def build_provider_index_by_name(providers: list[dict]) -> dict[str, dict]:
             raise ValueError(f"Duplicate provider name in providers.csv: '{name}'")
         idx[name] = p
     return idx
+
+
+def build_provider_index_by_slug(providers: list[dict]) -> dict[str, dict]:
+    idx = {}
+    for p in providers:
+        slug = p.get("slug")
+        if not isinstance(slug, str) or not slug.strip():
+            continue
+        if slug in idx:
+            raise ValueError(f"Duplicate provider slug in providers.csv: '{slug}'")
+        idx[slug] = p
+    return idx
+
+
+def resolve_offer_provider_slugs(
+    offers_by_category: dict[str, list[dict]],
+    provider_by_slug: dict[str, dict],
+) -> dict[str, list[dict]]:
+    """Resolve canonical offer provider slugs to display names for JSON output."""
+    for category, offers in offers_by_category.items():
+        for row_number, offer in enumerate(offers, start=2):
+            provider_slug = offer.get("providerSlug")
+            if not isinstance(provider_slug, str) or not provider_slug.strip():
+                raise ValueError(
+                    f"references/offers/{category}.csv row {row_number} has no providerSlug"
+                )
+
+            provider = provider_by_slug.get(provider_slug.strip())
+            if provider is None:
+                raise ValueError(
+                    f"references/offers/{category}.csv row {row_number} references "
+                    f"unknown providerSlug '{provider_slug}'"
+                )
+
+            offer["providerSlug"] = provider_slug.strip()
+            offer["provider"] = provider["name"]
+
+    return offers_by_category
 
 
 def collect_used_provider_names(data_by_category: dict[str, list[dict]]) -> set[str]:
@@ -648,9 +686,13 @@ def main():
     # References
     providers = load_providers("references/providers/providers.csv")
     provider_by_name = build_provider_index_by_name(providers)
+    provider_by_slug = build_provider_index_by_slug(providers)
     category_meta = load_json_file("meta/categories.json")
     column_meta = load_json_file("meta/columns.json")
-    offers_by_category = load_categories_from_folder("references/offers")
+    offers_by_category = resolve_offer_provider_slugs(
+        load_categories_from_folder("references/offers"),
+        provider_by_slug,
+    )
 
     # Global listings (apply to every network)
     global_listings = load_categories_from_folder(all_networks_dir)
@@ -722,6 +764,16 @@ def main():
             base_categories=list_categories(network_dir),
             extra_categories=global_listings_categories,
         )
+        for category, rows in result.items():
+            if category not in result["columns"]:
+                continue
+            if not any("providerSlug" in row for row in rows):
+                continue
+            columns = result["columns"][category]
+            if "providerSlug" in columns:
+                continue
+            insert_at = columns.index("provider") + 1 if "provider" in columns else 0
+            columns.insert(insert_at, "providerSlug")
         result["schemaVersion"] = schema_version
 
         provider_categories = collect_provider_categories(result)

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -35,6 +35,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "planName": { "type": ["string", "null"] },
         "planType": {
@@ -137,6 +138,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "chain": { "type": "string" },
         "technology": { "type": "string" },
@@ -192,6 +194,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "chain": { "type": "string" },
         "technology": { "type": "string" },
@@ -252,6 +255,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "chain": { "type": "string" },
         "technology": { "type": "string" },
@@ -328,6 +332,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "toolType": { "type": "string" },
         "price": { "type": ["string", "null"] },
@@ -371,6 +376,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "toolType": { "type": "string" },
         "price": { "type": ["string", "null"] },
@@ -413,6 +419,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "chain": { "type": "string" },
         "requiresLogin": { "type": "boolean" },
@@ -455,6 +462,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "chain": { "type": "string" },
         "dataSources": {
@@ -517,6 +525,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "openSource": { "type": "boolean" },
         "supportedPlatforms": {
@@ -581,6 +590,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "actionButtons": {
           "type": ["array", "null"],
@@ -646,6 +656,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "actionButtons": {
           "type": ["array", "null"],
@@ -705,6 +716,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "actionButtons": {
           "type": ["array", "null"],
@@ -744,6 +756,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "actionButtons": {
           "type": ["array", "null"],
@@ -794,6 +807,7 @@
       "properties": {
         "slug": { "type": "string" },
         "provider": { "type": "string" },
+        "providerSlug": { "type": "string" },
         "offer": { "type": ["string", "null"] },
         "actionButtons": {
           "type": ["array", "null"],

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -269,12 +269,16 @@ def load_csv_folder(folder) -> dict:
 
 def make_providers_schema(network_schema) -> dict:
     providers_schema = copy.deepcopy(network_schema)
-    for definition in providers_schema['$defs'].keys():
-        if definition == "columns":
+    for definition, definition_schema in providers_schema['$defs'].items():
+        if definition == "columns" or "required" not in definition_schema:
             continue
-        if "chain" in providers_schema['$defs'][definition]['required']:
-            index = providers_schema['$defs'][definition]['required'].index("chain")
-            del providers_schema['$defs'][definition]['required'][index]
+        if "chain" in definition_schema['required']:
+            definition_schema['required'].remove("chain")
+        if "provider" in definition_schema.get("properties", {}):
+            if "provider" in definition_schema['required']:
+                definition_schema['required'].remove("provider")
+            if "providerSlug" not in definition_schema['required']:
+                definition_schema['required'].append("providerSlug")
     return providers_schema
 
 def main():

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -84,11 +84,59 @@ def iter_csv_files(root: Path) -> Iterator[Path]:
             if name.lower().endswith(".csv"):
                 yield Path(dirpath) / name
 
+
+def rule_offer_provider_slug(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    """Require canonical offer rows to reference one provider slug exactly."""
+    if path.parent.name != "offers" or path.parent.parent.name != "references":
+        return []
+
+    errors: List[str] = []
+    if not rows:
+        return errors
+
+    if "provider" in rows[0]:
+        errors.append(
+            f"{path}: canonical offer tables must use 'providerSlug', not 'provider'"
+        )
+    if "providerSlug" not in rows[0]:
+        errors.append(f"{path}: canonical offer table is missing 'providerSlug'")
+        return errors
+
+    providers_path = path.parent.parent / "providers" / "providers.csv"
+    if not providers_path.exists():
+        return [f"{path}: provider registry not found at {providers_path}"]
+
+    with providers_path.open(newline="", encoding="utf-8") as f:
+        provider_rows = list(csv.DictReader(f))
+
+    provider_slugs = set()
+    for provider_row_number, provider in enumerate(provider_rows, start=2):
+        slug = (provider.get("slug") or "").strip()
+        if not slug:
+            errors.append(f"{providers_path}: row {provider_row_number} has an empty slug")
+        elif slug in provider_slugs:
+            errors.append(
+                f"{providers_path}: row {provider_row_number} duplicates provider slug '{slug}'"
+            )
+        provider_slugs.add(slug)
+
+    for row_number, row in enumerate(rows, start=2):
+        slug = (row.get("providerSlug") or "").strip()
+        if not slug:
+            errors.append(f"{path}: row {row_number} has an empty providerSlug")
+        elif slug not in provider_slugs:
+            errors.append(
+                f"{path}: row {row_number} references unknown providerSlug '{slug}'"
+            )
+
+    return errors
+
 def main():
     root = Path(".")
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_offer_provider_slug)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

Paired with #2608 for DBIP #2604.

- Adds `providerSlug` to the generated offer schema and column metadata.
- Requires canonical offer CSVs to use non-empty, unique, registry-resolvable provider slugs.
- Resolves canonical slugs to the existing human-readable `provider` field during JSON generation while retaining `providerSlug` for machine-readable joins.
- Prevents listing overrides from replacing canonical provider identity fields.
- Updates tooling documentation and source-schema validation for the new canonical field.

## Validation

- `python validate_csv.py` — all checks passed.
- `python csv_to_json.py` — generated 155 network JSON files; only pre-existing missing-chain warnings remain.
- `python validate.py` — all generated JSON schemas passed.
- Focused checks cover valid resolution, unknown slugs, legacy headers, source-schema requirements, and `martian-wallet` -> `Martian` display resolution.

## Settlement

Submitted under [DBIP #2604](https://github.com/Chain-Love/chain-love/issues/2604). The advertised DBIP reward is 10 USDC, contingent on approval and merge. Reward destination: the EVM address in the issue claim comment.