### PR TITLE
[DBIP #2584] Add API limit schema and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This guide explains how to **add new categories and columns for the Chain.Love p
 - `meta/categories.json` – category metadata.
 - `meta/columns.json` – column metadata.
 
+### API throughput and usage-quota fields
+
+The `apis` schema includes five optional normalized fields: `throughputLimit`, `throughputUnit`, `usageQuota`, `usageQuotaUnit`, and `quotaPeriod`. The two value fields are numeric in generated JSON. A throughput value must have a unit; a quota must have both a unit and a period. Units preserve provider-native terminology, including compute units, credits, and other capacity units.
+
+The fields are intentionally nullable. Contributors should leave them empty for custom or dynamic limits, ranges or alternative values, burst/soft/hard limits that cannot fit a single scalar, and any value not supported by the provider source. The existing `limitations` text remains the source-facing explanation.
+
 Data files are not documented in detail in this guide. Their structure and contribution flow are described in the `main` branch README: [README.md](https://github.com/Chain-Love/chain-love/blob/main/README.md).  
 However, schema/meta changes in this branch must be mirrored in data tables on `main` (for example when adding/removing categories or columns).
 
@@ -565,4 +571,3 @@ When asked to **remove a column**, an agent should:
   - Edit `tools/schema.json`: remove the column from every `$defs.<category>` where it appears.
   - Remove its entry from `meta/columns.json`.
   - On `main`, remove the column from every affected category CSV (see **§5**).
-

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -54,6 +54,61 @@
     "cellType": "arrayPopover",
     "group": "capabilities"
   },
+  "throughputLimit": {
+    "key": "throughputLimit",
+    "label": "Throughput Limit",
+    "icon": "lucide:Gauge",
+    "description": "Maximum documented processing throughput; paired with throughputUnit.",
+    "filter": "range",
+    "sorting": "number",
+    "pinning": null,
+    "cellType": "numericRange",
+    "group": "pricingAndSlas"
+  },
+  "throughputUnit": {
+    "key": "throughputUnit",
+    "label": "Throughput Unit",
+    "icon": "lucide:Gauge",
+    "description": "Unit associated with throughputLimit, preserving provider-native capacity terminology.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "pricingAndSlas"
+  },
+  "usageQuota": {
+    "key": "usageQuota",
+    "label": "Usage Quota",
+    "icon": "lucide:DatabaseZap",
+    "description": "Documented usage allowance; paired with usageQuotaUnit and quotaPeriod.",
+    "filter": "range",
+    "sorting": "number",
+    "pinning": null,
+    "cellType": "numericRange",
+    "group": "pricingAndSlas"
+  },
+  "usageQuotaUnit": {
+    "key": "usageQuotaUnit",
+    "label": "Usage Quota Unit",
+    "icon": "lucide:DatabaseZap",
+    "description": "Unit associated with usageQuota, preserving provider-native capacity terminology.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "pricingAndSlas"
+  },
+  "quotaPeriod": {
+    "key": "quotaPeriod",
+    "label": "Quota Period",
+    "icon": "lucide:CalendarClock",
+    "description": "Period over which usageQuota applies.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "pricingAndSlas"
+  },
   "offer": {
     "key": "offer",
     "label": "Offer",

--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -1,6 +1,8 @@
 import csv
 import json
+import math
 import os
+import re
 import string
 import unicodedata
 import warnings
@@ -13,6 +15,8 @@ SDK_TBD_FIELDS = (
     "maintainer",
     "license",
 )
+
+NUMERIC_FIELDS = frozenset({"throughputLimit", "usageQuota"})
 
 
 def col_letter(idx: int) -> str:
@@ -52,6 +56,25 @@ def is_trueish(value: str) -> bool:
     return isinstance(value, str) and value.strip().lower() == "true"
 
 
+def try_parse_number(value):
+    if isinstance(value, bool) or isinstance(value, (int, float)):
+        return value
+    if not isinstance(value, str):
+        return value
+
+    stripped = value.strip()
+    if stripped == "":
+        return value
+
+    if not re.fullmatch(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?", stripped):
+        return value
+
+    parsed = float(stripped)
+    if not math.isfinite(parsed):
+        return value
+    return int(parsed) if parsed.is_integer() else parsed
+
+
 def normalize(data_by_category: dict):
     result = {}
     errors = []
@@ -63,6 +86,14 @@ def normalize(data_by_category: dict):
                 new_item[key] = value
                 if is_nullish(value):
                     new_item[key] = None
+                elif key in NUMERIC_FIELDS:
+                    parsed = try_parse_number(value)
+                    if isinstance(parsed, str):
+                        errors.append(
+                            f"Value '{value}' for key '{key}' in category '{category}' must be numeric"
+                        )
+                    else:
+                        new_item[key] = parsed
                 if is_boolish(value):
                     new_item[key] = is_trueish(value)
                 try:

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -69,6 +69,28 @@
           "type": ["array", "null"],
           "items": { "type": "string" }
         },
+        "throughputLimit": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Maximum documented processing throughput. Leave null when the source is ambiguous or dynamic."
+        },
+        "throughputUnit": {
+          "type": ["string", "null"],
+          "description": "Unit associated with throughputLimit, preserving the provider's native capacity unit."
+        },
+        "usageQuota": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "description": "Documented usage allowance or quota. Leave null when the source is ambiguous or dynamic."
+        },
+        "usageQuotaUnit": {
+          "type": ["string", "null"],
+          "description": "Unit associated with usageQuota, preserving the provider's native capacity unit."
+        },
+        "quotaPeriod": {
+          "type": ["string", "null"],
+          "description": "Period over which usageQuota applies."
+        },
         "securityImprovements": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -116,6 +138,11 @@
         "trial",
         "availableApis",
         "limitations",
+        "throughputLimit",
+        "throughputUnit",
+        "usageQuota",
+        "usageQuotaUnit",
+        "quotaPeriod",
         "securityImprovements",
         "monitoringAndAnalytics",
         "regions",

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import math
 from jsonschema import Draft202012Validator
 from jsonpointer import resolve_pointer
 import copy
@@ -93,6 +94,42 @@ def rule_chain_is_lowercase(data):
             continue
         if not item["chain"].islower():
             errors.append(f"Item {idx}: chain must be lowercase: want '{item['chain'].lower()}', got '{item['chain']}'. Please check all categories for the current network.")
+    return errors
+
+
+def rule_api_limits(data):
+    """Validate normalized API throughput/quota field relationships."""
+    if not data or not any(key in data[0] for key in (
+        "throughputLimit", "throughputUnit", "usageQuota", "usageQuotaUnit", "quotaPeriod"
+    )):
+        return []
+
+    errors = []
+
+    def present(value):
+        return value is not None and (not isinstance(value, str) or value.strip() != "")
+
+    def numeric(value):
+        return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value) and value >= 0
+
+    for idx, item in enumerate(data):
+        throughput = item.get("throughputLimit")
+        throughput_unit = item.get("throughputUnit")
+        quota = item.get("usageQuota")
+        quota_unit = item.get("usageQuotaUnit")
+        quota_period = item.get("quotaPeriod")
+
+        if present(throughput) and not numeric(throughput):
+            errors.append(f"Item {idx}: throughputLimit must be a non-negative number")
+        if present(quota) and not numeric(quota):
+            errors.append(f"Item {idx}: usageQuota must be a non-negative number")
+        if present(throughput) != present(throughput_unit):
+            errors.append(f"Item {idx}: throughputLimit and throughputUnit must be supplied together")
+        if present(quota) != (present(quota_unit) and present(quota_period)):
+            errors.append(f"Item {idx}: usageQuota, usageQuotaUnit, and quotaPeriod must be supplied together")
+        if not present(quota) and (present(quota_unit) or present(quota_period)):
+            errors.append(f"Item {idx}: quota unit/period cannot be supplied without usageQuota")
+
     return errors
 
 def has_unclosed_markdown(s: str) -> bool:
@@ -291,6 +328,7 @@ def main():
     rules.add_rule(rule_provider_casing_consistent)
     rules.add_rule(rule_slug_kebab_case)
     rules.add_rule(rule_chain_is_lowercase)
+    rules.add_rule(rule_api_limits)
 
     # Validate networks
     validator = Draft202012Validator(schema)

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Iterator, Callable, List, Dict
 import os
 import csv
+import math
 import re
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
@@ -78,6 +79,56 @@ def rule_links_must_be_quoted(path: Path, rows: List[Dict[str, str]]) -> List[st
 
     return errors
 
+
+def rule_api_limit_fields(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    """Validate pairing and raw numeric syntax for the optional API limit fields."""
+    if path.name != "apis.csv" or not rows:
+        return []
+
+    fields = {"throughputLimit", "throughputUnit", "usageQuota", "usageQuotaUnit", "quotaPeriod"}
+    if not fields.intersection(rows[0].keys()):
+        return []
+
+    errors: List[str] = []
+
+    def present(value) -> bool:
+        return value is not None and str(value).strip() != ""
+
+    def numeric(value) -> bool:
+        if not present(value):
+            return True
+        try:
+            parsed = float(str(value).strip())
+        except ValueError:
+            return False
+        return math.isfinite(parsed) and parsed >= 0
+
+    for idx, row in enumerate(rows, start=2):
+        throughput = row.get("throughputLimit")
+        throughput_unit = row.get("throughputUnit")
+        quota = row.get("usageQuota")
+        quota_unit = row.get("usageQuotaUnit")
+        quota_period = row.get("quotaPeriod")
+
+        if not numeric(throughput):
+            errors.append(f"{path}: row {idx}: throughputLimit must be a non-negative number")
+        if not numeric(quota):
+            errors.append(f"{path}: row {idx}: usageQuota must be a non-negative number")
+
+        if present(throughput) != present(throughput_unit):
+            errors.append(f"{path}: row {idx}: throughputLimit and throughputUnit must be supplied together")
+
+        quota_present = present(quota)
+        quota_parts_present = present(quota_unit) and present(quota_period)
+        if quota_present != quota_parts_present:
+            errors.append(
+                f"{path}: row {idx}: usageQuota, usageQuotaUnit, and quotaPeriod must be supplied together"
+            )
+        if not quota_present and (present(quota_unit) or present(quota_period)):
+            errors.append(f"{path}: row {idx}: quota unit/period cannot be supplied without usageQuota")
+
+    return errors
+
 def iter_csv_files(root: Path) -> Iterator[Path]:
     for dirpath, _, filenames in os.walk(root):
         for name in sorted(filenames):
@@ -89,6 +140,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_api_limit_fields)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

Implements the schema and tooling side of DBIP #2584.

- Adds the five optional API limit fields to the API JSON Schema and metadata.
- Converts the two numeric CSV fields to JSON numbers during generation.
- Adds CSV-level and generated-JSON-level validation for non-negative numeric values and complete field pairing.
- Documents the nullable/source-backed policy for custom, dynamic, range, alternative, and burst/soft/hard limits.

## Validation

- JSON syntax and Python compilation passed.
- `git diff --check` passed.
- Paired with the data PR, full CSV -> JSON generation completed and the Draft 2020-12 validator passed for all generated networks and provider offers.
- Paired data PR: #2611.

Implements #2584.