### PR TITLE
Add security language and framework schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ This guide explains how to **add new categories and columns for the Chain.Love p
 Data files are not documented in detail in this guide. Their structure and contribution flow are described in the `main` branch README: [README.md](https://github.com/Chain-Love/chain-love/blob/main/README.md).  
 However, schema/meta changes in this branch must be mirrored in data tables on `main` (for example when adding/removing categories or columns).
 
+### Security capability columns
+
+The `security` schema exposes two nullable array fields: `supportedLanguages`
+contains provider-documented source or smart-contract languages, while
+`supportedFrameworks` contains provider-documented build, development, or
+testing integrations. These fields are intentionally separate from
+`executionEnvironment`, `deliveryType`, and `coverage`; blank values remain
+valid when support is not documented. The CSV and normalized-data validators
+require populated arrays to contain non-empty, trimmed, deduplicated strings.
+
 ---
 
 ## 1. Files and responsibilities
@@ -565,4 +575,3 @@ When asked to **remove a column**, an agent should:
   - Edit `tools/schema.json`: remove the column from every `$defs.<category>` where it appears.
   - Remove its entry from `meta/columns.json`.
   - On `main`, remove the column from every affected category CSV (see **§5**).
-

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -890,6 +890,28 @@
     "cellType": null,
     "group": "technicalDetails"
   },
+  "supportedLanguages": {
+    "key": "supportedLanguages",
+    "label": "Supported Languages",
+    "icon": "lucide:Code2",
+    "description": "Provider-documented source or smart-contract languages supported for security analysis, testing, scanning, or audits.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "technicalDetails"
+  },
+  "supportedFrameworks": {
+    "key": "supportedFrameworks",
+    "label": "Supported Frameworks",
+    "icon": "lucide:Workflow",
+    "description": "Provider-documented build, development, or testing framework integrations or project ingestion paths.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "technicalDetails"
+  },
   "kycLevel": {
     "key": "kycLevel",
     "label": "KYC Level",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -826,6 +826,16 @@
         "compliance": {
           "type": ["array", "null"],
           "items": { "type": "string" }
+        },
+        "supportedLanguages": {
+          "type": ["array", "null"],
+          "items": { "type": "string" },
+          "description": "Provider-documented source or smart-contract languages supported for analysis, testing, scanning, or audit work."
+        },
+        "supportedFrameworks": {
+          "type": ["array", "null"],
+          "items": { "type": "string" },
+          "description": "Provider-documented build, development, or testing frameworks supported through direct integration or project ingestion."
         }
       },
       "required": [
@@ -843,7 +853,9 @@
         "deliveryType",
         "executionEnvironment",
         "coverage",
-        "compliance"
+        "compliance",
+        "supportedLanguages",
+        "supportedFrameworks"
       ]
     },
     "agents": {

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -77,6 +77,38 @@ def rule_action_buttons_is_list_of_links(data):
                 errors.append(f"Item {idx}: action_button[{item_idx}] must be a markdown link")
     return errors
 
+def rule_security_capability_arrays(data):
+    errors = []
+    fields = ("supportedLanguages", "supportedFrameworks")
+
+    for idx, item in enumerate(data):
+        for field in fields:
+            if field not in item:
+                continue
+
+            value = item.get(field)
+            if value is None:
+                continue
+            if type(value) is not list:
+                errors.append(f"Item {idx}: {field} must be an array or null")
+                continue
+            if not value:
+                errors.append(f"Item {idx}: {field} must not be an empty array")
+                continue
+
+            seen = set()
+            for item_idx, entry in enumerate(value):
+                if type(entry) is not str or not entry.strip():
+                    errors.append(f"Item {idx}: {field}[{item_idx}] must be a non-empty string")
+                    continue
+                if entry != entry.strip():
+                    errors.append(f"Item {idx}: {field}[{item_idx}] must not have leading or trailing whitespace")
+                if entry in seen:
+                    errors.append(f"Item {idx}: {field} contains duplicate value '{entry}'")
+                seen.add(entry)
+
+    return errors
+
 def rule_no_unclosed_markdown(data):
     errors = []
     for idx, item in enumerate(data):
@@ -288,6 +320,7 @@ def main():
     rules.add_rule(rule_slug_unique)
     rules.add_rule(rule_no_unclosed_markdown)
     rules.add_rule(rule_action_buttons_is_list_of_links)
+    rules.add_rule(rule_security_capability_arrays)
     rules.add_rule(rule_provider_casing_consistent)
     rules.add_rule(rule_slug_kebab_case)
     rules.add_rule(rule_chain_is_lowercase)

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Iterator, Callable, List, Dict
 import os
 import csv
+import json
 import re
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
@@ -50,6 +51,48 @@ def rule_slug_sorted(path: Path, rows: List[Dict[str, str]]) -> List[str]:
 
     return errors
 
+def rule_security_capability_arrays(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    if path.name != "security.csv":
+        return []
+
+    errors: List[str] = []
+    fields = ("supportedLanguages", "supportedFrameworks")
+
+    for idx, row in enumerate(rows, start=2):
+        for field in fields:
+            if field not in row:
+                continue
+
+            raw = row.get(field, "")
+            if raw is None or raw.strip() == "" or raw.strip().lower() == "null":
+                continue
+
+            try:
+                value = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path}: row {idx}: {field} must be a JSON array or NULL: {exc.msg}")
+                continue
+
+            if not isinstance(value, list):
+                errors.append(f"{path}: row {idx}: {field} must be a JSON array or NULL")
+                continue
+            if not value:
+                errors.append(f"{path}: row {idx}: {field} must not be an empty array")
+                continue
+
+            seen = set()
+            for item_idx, item in enumerate(value):
+                if not isinstance(item, str) or not item.strip():
+                    errors.append(f"{path}: row {idx}: {field}[{item_idx}] must be a non-empty string")
+                    continue
+                if item != item.strip():
+                    errors.append(f"{path}: row {idx}: {field}[{item_idx}] must not have leading or trailing whitespace")
+                if item in seen:
+                    errors.append(f"{path}: row {idx}: {field} contains duplicate value '{item}'")
+                seen.add(item)
+
+    return errors
+
 def looks_like_url(v: str) -> bool:
     return v.startswith("http://") or v.startswith("https://")
 
@@ -89,6 +132,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_security_capability_arrays)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

- Add `supportedLanguages` and `supportedFrameworks` as nullable arrays to the security schema.
- Add searchable array metadata for both fields.
- Validate populated arrays in both raw CSV and normalized JSON data: non-empty, trimmed, string-only, and deduplicated.
- Document the distinction from `executionEnvironment`, `deliveryType`, and `coverage`.

## Validation

- Generated every network JSON file with `csv_to_json.py`.
- Ran the normalized-data validator across the generated network set with no errors.
- Ran the raw CSV validator across the repository with no errors.

## Related work

- DBIP: https://github.com/Chain-Love/chain-love/issues/2409
- Paired data branch: `agent/dbip-2409-security-languages-data`

Reward destination: `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00` (Ethereum Mainnet).
