### PR TITLE
[DBIP #1805] Add payments category schema and validation

### DIFF
--- a/meta/categories.json
+++ b/meta/categories.json
@@ -78,6 +78,12 @@
     "icon": "lucide:LayoutGrid",
     "description": "Infrastructure platforms and stacks."
   },
+  "payments": {
+    "key": "payments",
+    "label": "Payments",
+    "icon": "lucide:CreditCard",
+    "description": "Checkout, payment links, merchant gateways, x402 flows, paymasters, and on-chain payout tools."
+  },
   "security": {
     "key": "security",
     "label": "Security",

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -901,6 +901,50 @@
     "cellType": null,
     "group": "serviceDetails"
   },
+  "paymentType": {
+    "key": "paymentType",
+    "label": "Payment Type",
+    "icon": "lucide:ShoppingCart",
+    "description": "Primary payment flow or settlement product type.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "serviceDetails"
+  },
+  "settlementAssets": {
+    "key": "settlementAssets",
+    "label": "Settlement Assets",
+    "icon": "lucide:Coins",
+    "description": "Assets used for payment settlement when documented.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "settlementChains": {
+    "key": "settlementChains",
+    "label": "Settlement Chains",
+    "icon": "lucide:Link",
+    "description": "Networks used for payment settlement when documented.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "developerInterface": {
+    "key": "developerInterface",
+    "label": "Developer Interface",
+    "icon": "lucide:CodeXml",
+    "description": "Integration surfaces such as APIs, SDKs, payment links, or MCP.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "technicalDetails"
+  },
   "paymentMethods": {
     "key": "paymentMethods",
     "label": "Payment Methods",
@@ -911,6 +955,28 @@
     "pinning": null,
     "cellType": "arrayPopover",
     "group": "pricing"
+  },
+  "onChainSettlement": {
+    "key": "onChainSettlement",
+    "label": "On-Chain Settlement",
+    "icon": "lucide:Blocks",
+    "description": "Whether payment settlement occurs on-chain.",
+    "filter": "select",
+    "sorting": "boolean",
+    "pinning": null,
+    "cellType": null,
+    "group": "capabilities"
+  },
+  "nonCustodial": {
+    "key": "nonCustodial",
+    "label": "Non-Custodial",
+    "icon": "lucide:KeyRound",
+    "description": "Whether users retain control of the funds or signing wallet.",
+    "filter": "select",
+    "sorting": "boolean",
+    "pinning": null,
+    "cellType": null,
+    "group": "security"
   },
   "serverType": {
     "key": "serverType",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -23,6 +23,7 @@
     "sdks": { "type": "array", "items": { "$ref": "#/$defs/sdks" } },
     "ramps": { "type": "array", "items": { "$ref": "#/$defs/ramps" } },
     "platforms": { "type": "array", "items": { "$ref": "#/$defs/platforms" } },
+    "payments": { "type": "array", "items": { "$ref": "#/$defs/payments" } },
     "security": { "type": "array", "items": { "$ref": "#/$defs/security" } },
     "agents": { "type": "array", "items": { "$ref": "#/$defs/agents" } },
     "columns": { "$ref": "#/$defs/columns" },
@@ -787,6 +788,92 @@
         "executionEnvironment"
       ]
     },
+    "payments": {
+      "title": "Payments",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "slug": { "type": "string" },
+        "provider": { "type": "string" },
+        "offer": { "type": ["string", "null"] },
+        "actionButtons": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "paymentType": { "type": "string" },
+        "settlementAssets": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "settlementChains": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "custodial": { "type": ["boolean", "null"] },
+        "kycLevel": { "type": ["string", "null"] },
+        "developerInterface": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "planType": {
+          "type": "string",
+          "examples": [
+            "Free",
+            "Pay-as-you-go",
+            "Enterprise",
+            "Dedicated",
+            "Tiered",
+            "One-time payment"
+          ]
+        },
+        "planName": { "type": ["string", "null"] },
+        "price": { "type": ["string", "null"] },
+        "trial": { "type": "boolean" },
+        "starred": { "type": "boolean" },
+        "x402": { "type": ["boolean", "null"] },
+        "onChainSettlement": { "type": ["boolean", "null"] },
+        "paymentMethods": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "nonCustodial": { "type": ["boolean", "null"] },
+        "regions": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "limitations": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "tag": { "type": ["array", "null"], "items": { "type": "string" } },
+        "description": { "type": ["string", "null"] }
+      },
+      "required": [
+        "slug",
+        "provider",
+        "offer",
+        "actionButtons",
+        "paymentType",
+        "settlementAssets",
+        "settlementChains",
+        "custodial",
+        "kycLevel",
+        "developerInterface",
+        "planType",
+        "planName",
+        "price",
+        "trial",
+        "starred",
+        "x402",
+        "onChainSettlement",
+        "paymentMethods",
+        "nonCustodial",
+        "regions",
+        "limitations",
+        "tag",
+        "description"
+      ]
+    },
     "security": {
       "title": "Security",
       "type": "object",
@@ -970,6 +1057,7 @@
         "storages": { "type": "array", "items": { "type": "string" } },
         "sdks": { "type": "array", "items": { "type": "string" } },
         "platforms": { "type": "array", "items": { "type": "string" } },
+        "payments": { "type": "array", "items": { "type": "string" } },
         "security": { "type": "array", "items": { "type": "string" } },
         "agents": { "type": "array", "items": { "type": "string" } }
       }
@@ -1068,6 +1156,7 @@
               "sdks",
               "ramps",
               "platforms",
+              "payments",
               "security",
               "agents"
             ]

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -95,6 +95,38 @@ def rule_chain_is_lowercase(data):
             errors.append(f"Item {idx}: chain must be lowercase: want '{item['chain'].lower()}', got '{item['chain']}'. Please check all categories for the current network.")
     return errors
 
+def rule_payments_fields(data):
+    """Validate shared shapes and invariants for the payments category."""
+    errors = []
+    array_fields = (
+        "settlementAssets",
+        "settlementChains",
+        "developerInterface",
+        "paymentMethods",
+        "regions",
+        "limitations",
+        "tag",
+    )
+
+    for idx, item in enumerate(data):
+        if "paymentType" not in item:
+            continue
+
+        for field in array_fields:
+            value = item.get(field)
+            if value is None:
+                continue
+            if type(value) is not list or any(type(entry) is not str or not entry.strip() for entry in value):
+                errors.append(f"Item {idx}: payments field '{field}' must be a list of non-empty strings or null")
+                continue
+            if len(set(value)) != len(value):
+                errors.append(f"Item {idx}: payments field '{field}' must not contain duplicate values")
+
+        if item.get("custodial") is True and item.get("nonCustodial") is True:
+            errors.append(f"Item {idx}: custodial and nonCustodial cannot both be true")
+
+    return errors
+
 def has_unclosed_markdown(s: str) -> bool:
     if type(s) != str:
         return False
@@ -291,6 +323,7 @@ def main():
     rules.add_rule(rule_provider_casing_consistent)
     rules.add_rule(rule_slug_kebab_case)
     rules.add_rule(rule_chain_is_lowercase)
+    rules.add_rule(rule_payments_fields)
 
     # Validate networks
     validator = Draft202012Validator(schema)

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -3,6 +3,7 @@ from typing import Iterator, Callable, List, Dict
 import os
 import csv
 import re
+import json
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
 
@@ -78,6 +79,40 @@ def rule_links_must_be_quoted(path: Path, rows: List[Dict[str, str]]) -> List[st
 
     return errors
 
+def rule_payments_array_fields(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    """Check JSON-array columns in payments CSV files before generation."""
+    if "paymentType" not in (rows[0].keys() if rows else []):
+        return []
+
+    array_fields = (
+        "settlementAssets",
+        "settlementChains",
+        "developerInterface",
+        "paymentMethods",
+        "regions",
+        "limitations",
+        "tag",
+    )
+    errors: List[str] = []
+
+    for row_idx, row in enumerate(rows, start=2):
+        for field in array_fields:
+            raw = (row.get(field) or "").strip()
+            if not raw:
+                continue
+            try:
+                value = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path}: row {row_idx}: payments field '{field}' is not valid JSON: {exc.msg}")
+                continue
+            if type(value) is not list or any(type(entry) is not str or not entry.strip() for entry in value):
+                errors.append(f"{path}: row {row_idx}: payments field '{field}' must be a JSON array of non-empty strings")
+                continue
+            if len(set(value)) != len(value):
+                errors.append(f"{path}: row {row_idx}: payments field '{field}' must not contain duplicate values")
+
+    return errors
+
 def iter_csv_files(root: Path) -> Iterator[Path]:
     for dirpath, _, filenames in os.walk(root):
         for name in sorted(filenames):
@@ -89,6 +124,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_payments_array_fields)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

- Register the new `payments` category in the top-level schema, columns map, provider category enum, and category metadata.
- Define payment comparison fields for payment type, settlement assets/chains, custody, developer interfaces, x402, on-chain settlement, and payment methods.
- Add UI metadata for the new columns.
- Add CSV and generated-data validation for JSON-array fields and contradictory custody flags.

## Related work

- DBIP #1805: https://github.com/Chain-Love/chain-love/issues/1805
- Paired data branch: `agent/dbip-1805-payments-data`
- Grant discussion: https://github.com/Chain-Love/chain-love/discussions/41

## Validation

- `python3 tools/validate_csv.py` — passed on the combined data checkout.
- `python3 -m json.tool tools/schema.json` and metadata JSON parsing — passed.
- Combined data + tool validation generated 155 network JSON files and passed the repository JSON Schema/rule validator with the bundled dependency environment.

## Reward

If accepted under the approved DBIP grant, send the reward to `0xB12831cF8490f7A47Da0A9B8D61e78bb8D0B2d00`.
