### PR TITLE
feat(somnia): add ConnectKit SDK listing

### DIFF
--- a/listings/specific-networks/somnia/sdks.csv
+++ b/listings/specific-networks/somnia/sdks.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,toolType,programmingLanguage,tag,description,planType,planName,price,trial,starred,dependencies,latestKnownVersion,latestKnownReleaseDate,maintainer,license
 alloy,,!offer:alloy,,,,,,,,,,,,,,,
+connectkit,,!offer:connectkit,"[""[Docs](https://docs.somnia.network/developer/building-dapps/wallet-integration-and-auth/authenticating-with-connectkit)""]",,,,,,,,,,,,,,
 ens-js,,!offer:ens-js,,,,,,,,,,,,,,,
 ethers-js,,!offer:ethers-js,,,,,,,,,,,,,,,
 foundry,,!offer:foundry,"[""[Docs](https://docs.somnia.network/developer/development-frameworks/deploy-with-foundry)""]",,,,,,,,,,,,,,


### PR DESCRIPTION
Adds ConnectKit to the Somnia SDK listings. ConnectKit has an official integration guide on the Somnia docs (https://docs.somnia.network/developer/building-dapps/wallet-integration-and-auth/authenticating-with-connectkit) and is absent from all-networks listings, so no duplicate is introduced. Locally validated with validate_csv.py, csv_to_json.py and validate.py.