### PR TITLE
feat(somnia): add Blockscout MCP server listing

### DIFF
--- a/listings/specific-networks/somnia/mcpservers.csv
+++ b/listings/specific-networks/somnia/mcpservers.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
+blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
 coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,,,,,
+li-fi-mcp,,!offer:li-fi-mcp,,,,,,,,,,,,,,,,,,,,
 wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/somnia/mcpservers.csv
+++ b/listings/specific-networks/somnia/mcpservers.csv
@@ -1,5 +1,4 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
 blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
 coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,,,,,
-li-fi-mcp,,!offer:li-fi-mcp,,,,,,,,,,,,,,,,,,,,
 wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Adds the existing canonical `blockscout-mcp` offer to Somnia's network-specific MCP listings.

Blockscout is Somnia's official explorer infrastructure, and its official hosted MCP server exposes multi-chain explorer data to agents. The canonical MCP offer and endpoint already exist in `references/offers/mcpservers.csv`; this PR adds only the missing Somnia network association.

`li-fi-mcp` is intentionally not added here because it already exists in `listings/all-networks/mcpservers.csv` and is therefore generated for Somnia automatically. A Somnia-specific duplicate would produce two identical LI.FI entities.

## Verification

- `validate_csv.py` — passed
- `csv_to_json.py` — passed
- `validate.py` — passed
- Generated `somnia.json`: `blockscout-mcp` count = 1, `li-fi-mcp` count = 1
- CSV schema/order/reference checks — passed
- Independent review — approved

## Sources

- Somnia explorer documentation: https://docs.somnia.network/developer/deployment-and-production/ecosystem/ecosystem-tools/explorers
- Somnia explorer API documentation: https://docs.somnia.network/developer/deployment-and-production/explorer-api-health-and-monitoring
- Blockscout MCP source: https://github.com/blockscout/mcp-server

## Reward classification

`VALIDATION_PORTFOLIO`: 2 non-null listing cells x 0.06 USDC x MCP multiplier 1.39 = **0.1668 USDC conditional**. This is not counted as earned revenue unless approved, merged, and settled.

## AI disclosure

AI assistance was used for research, validation orchestration, and drafting. The final source mapping, generated output, diff, and links were independently verified.

Reward address: `0xBc14D9C1E2202E3385e7FE89D5d65D42c90ECaB8`
