### PR TITLE
Add Somnia Stork oracle contract links

### DIFF
--- a/listings/specific-networks/somnia/oracles.csv
+++ b/listings/specific-networks/somnia/oracles.csv
@@ -8,4 +8,4 @@ dia-testnet,,!offer:dia,"[""[Docs](https://www.diadata.org/docs/nexus/how-to-gui
 protofire-mainnet,,!offer:protofire,"[""[Website](https://protofire.io/services/oracle-integration/)"",""[Docs](https://docs.somnia.network/developer/building-dapps/oracles/protofire-price-feeds)""]",mainnet,,,,,"[""AggregatorV3Interface compatibility"",""Read-only proxy contracts"",""VRF""]","[""BTC/USD"",""ETH/USD"",""USDC/USD"",""Randomness""]",,,,,,
 protofire-testnet,,!offer:protofire,"[""[Website](https://protofire.io/services/oracle-integration/)"",""[Docs](https://docs.somnia.network/developer/building-dapps/oracles/protofire-price-feeds)""]",testnet,,,,,,"[""BTC/USD"",""ETH/USD"",""USDC/USD"",""Randomness""]",,,,,,
 scry-protocol-mainnet,,!offer:scry-protocol,,mainnet,,,,,,,,,,,,
-stork-testnet,,!offer:stork,,testnet,,,,,,,,,,,,
+stork-testnet,,!offer:stork,"[""[Docs](https://docs.stork.network/resources/contract-addresses/evm)"",""[Contract](https://shannon-explorer.somnia.network/address/0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62)""]",testnet,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Enrich the existing Somnia Stork oracle listing with network-specific links:

- Stork's official EVM contract-address documentation
- the deployed Stork contract on Somnia Shannon Testnet explorer

The row keeps the existing `!offer:stork` inheritance for canonical Stork metadata and only fills the Somnia-specific `actionButtons` cell.

## Type of change
- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [x] Documentation/metadata only

## Scope
- Networks affected: somnia
- Categories affected: oracles

- Additional notes, additional context / screenshots: This is limited to the existing `stork-testnet` listing and adds only verified, network-specific links.

## Links
- Stork EVM contract-address documentation: https://docs.stork.network/resources/contract-addresses/evm
- Somnia Shannon Testnet contract: https://shannon-explorer.somnia.network/address/0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62
- Related issue(s)/ DB Improvement Proposal: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions and used the existing `!offer:stork` reference for inheritance.
- [x] I personally opened and verified every new link I'm adding; both links return successfully.
- [x] I confirmed the Stork contract address against Stork's official EVM contract-address documentation and the Somnia Shannon explorer.
- [x] This is a targeted, source-verified contribution.

## Optional
- Rewards address (for data patching rewards): 0xEA102cf5930eec97b0D39B916F82a46eAeA5f1B7
- Twitter (X) post link: not included

## Validation performed
- `python3 git-hooks/pre-commit.py`
- Direct link checks for both added URLs returned HTTP 200.
