### PR TITLE
Extend Tenderly entries

### DIFF
--- a/listings/specific-networks/ethereum/explorers.csv
+++ b/listings/specific-networks/ethereum/explorers.csv
@@ -19,6 +19,7 @@ jiffyscan-developer,,!offer:jiffyscan-developer,"[""[Explore](https://jiffyscan.
 jiffyscan-professional,,!offer:jiffyscan-professional,"[""[Explore](https://jiffyscan.xyz/pricing)""]",mainnet,,,,,,,,,,,
 jiffyscan-starter,,!offer:jiffyscan-starter,"[""[Explore](https://jiffyscan.xyz/pricing)""]",mainnet,,,,,,,,,,,
 routescan-mainnet,,!offer:routescan,,mainnet,,,,,,,,,,,
+tenderly-explorer-mainnet,,!offer:tenderly-explorer,,mainnet,,,,,,,,,,,
 tokenterminal-explorer-mainnet,,!offer:tokenterminal-explorer,"[""[Explore](https://tokenterminal.com/explorer/projects/ethereum)""]",mainnet,,,,,,,,,,,
 tokenview-mainnet,,!offer:tokenview,"[""[Explore](https://eth.tokenview.io)""]",mainnet,,,,,,,,,,,
 uviblock-mainnet,,!offer:uviblock,"[""[Explore](https://app.uviblock.com/ethereum)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Added listing data for existing offers in Explorers. Listing rows added: 1. Example listing slug: `tenderly-explorer-mainnet`.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change (requires linked DBIP)
- [ ] Documentation/metadata only

## Scope
- **Networks affected**: mainnet
- **Categories affected**: Explorers
- Additional notes (constraints, naming, normalization), additional context / screenshots: Generated via Chain.Love Contributor by @targetspartan97-create.

CSV preview:
```csv
tenderly-explorer-mainnet,,!offer:tenderly-explorer,,mainnet,,,,,,,,,,,
```

## Links
- Related issue(s): N/A
- DB Improvement Proposal (DBIP), if schema-related: N/A

## Validation checklist
- [x] I followed the Style Guide and Column Definitions
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] Rows are placed in the correct folder(s) and CSV(s)
  - `listings/specific-networks/<chain>/<category>.csv` for chain-scoped entries
  - `references/offers/<category>.csv` for offer entries
- [x] No duplicate entries (by provider + chain + relevant key columns)
- [x] CSV formatting: comma-delimited, quote fields as needed, UTF-8, no BOM
- [x] Values match defined types/enums per Column Definitions
- [x] No unintended whitespace, trailing commas, or empty lines

## Optional
- Rewards address (for data patching rewards): 0xac0F824579fa5f1e24b6665E9CA2B5088C3105dC
- Twitter (X) post link (for +10% of rewards to this PR): Not provided