### PR TITLE
feat(algorand): add NowPayments ALGO payment gateway to services listing

### DIFF
--- a/listings/specific-networks/algorand/services.csv
+++ b/listings/specific-networks/algorand/services.csv
@@ -6,3 +6,4 @@ avm-debugger,,!offer:avm-debugger,"[""[Docs](https://dev.algorand.co/algokit/avm
 client-generator,,!offer:client-generator,"[""[TypeScript Docs](https://dev.algorand.co/algokit/client-generator/typescript/)"",""[Python Docs](https://dev.algorand.co/algokit/client-generator/python/)""]",,,,,,,
 mosaia-explorer,,!offer:mosaia-explorer,,,,,,,,
 mosaia-pro,,!offer:mosaia-pro,,,,,,,,
+nowpayments,,!offer:nowpayments,"[""[Website](https://nowpayments.io/supported-coins/algo-payments)""]",,,,,,,


### PR DESCRIPTION
## Summary

Adds the existing canonical `nowpayments` offer to Algorand's network-specific **services** listing.

NowPayments is a non-custodial crypto payment gateway that supports ALGO (Algorand). This PR adds the missing Algorand network association, mirroring the existing pattern used for zcash (`listings/specific-networks/zcash/services.csv`).

## Verification

- `validate_csv.py` — passed
- `csv_to_json.py` — passed (generated `algorand.json` contains exactly one `nowpayments` entity, correct provider/offer/category)
- `validate.py` — passed
- CSV schema/order/reference checks — passed
- Independent review — approved, 0 findings

## Sources

- NowPayments official Algorand payment page: https://nowpayments.io/supported-coins/algo-payments
- NowPayments public currencies API (`GET https://api.nowpayments.io/v1/currencies`) lists `algo`
- Row format reference (zcash): https://nowpayments.io/supported-coins/zcash-payments

## Reward classification

`VALIDATION_PORTFOLIO`: 3 non-null listing cells (slug, offer, actionButtons) x 0.06 USDC x services multiplier 1.36 = **0.2448 USDC conditional**. This is not counted as earned revenue unless approved, merged, and settled.

## AI disclosure

AI assistance was used for research, validation orchestration, and drafting. The final source mapping, generated output, diff, and links were independently verified.

Reward address: `0xBc14D9C1E2202E3385e7FE89D5d65D42c90ECaB8`
