### PR TITLE
docs(algorand): link Pera yearly security audits

### DIFF
--- a/listings/specific-networks/algorand/wallets.csv
+++ b/listings/specific-networks/algorand/wallets.csv
@@ -14,7 +14,7 @@ ledger,,!offer:ledger,"[""[Algorand Wallet](https://www.ledger.com/coin/wallet/a
 lute,Lute,,"[""[Website](https://lute.app/)""]",FALSE,"[""Web"","" Chrome""]",FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,FALSE,FALSE,"[""ARC-60""]",FALSE,$0,"[""[telegram](Lute.algo Wallet - Official & Support)"",""website"",""twitter""]",,"[""EN""]",FALSE,
 nufi-wallet,,!offer:nufi-wallet,,,,,,,,,,,,,,,,,,,
 onekey,,!offer:onekey,"[""[Algorand Wallet](https://onekey.so/cryptos/algorand/)""]",,,,,,,,,,,,,,,,,,
-pera,Pera,,"[""[Website](https://perawallet.app/)""]",TRUE,"[""Web"",""iOS"",""Android""]",FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,"[""ALGO"",""Algorand Standard Assets (ASA)""]",TRUE,$0,"[""helpdesk"",""telegram"",""github"",""reddit"",""discord"",""[chat support widget](perawallet.app/contact-us/)""]",,"[""EN"",""ID""]",FALSE,
+pera,Pera,,"[""[Website](https://perawallet.app/)""]",TRUE,"[""Web"",""iOS"",""Android""]",FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,"[""ALGO"",""Algorand Standard Assets (ASA)""]",TRUE,$0,"[""helpdesk"",""telegram"",""github"",""reddit"",""discord"",""[chat support widget](perawallet.app/contact-us/)""]","[""[Yearly security audits](https://support.perawallet.app/en/article/pera-web-wallet-security-measures-comparison-with-myalgo-1x4qx4v/)""]","[""EN"",""ID""]",FALSE,
 ronin-wallet,,!offer:ronin-wallet,,,,,,,,,,,,,,,,,,,
 saakuru-wallet,,!offer:saakuru-wallet,,,,,,,,,,,,,,,,,,,
 trustwallet,,!offer:trustwallet,"[""[Algorand Wallet](https://trustwallet.com/algorand-wallet)""]",,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Populates the empty audit field on the existing Algorand Pera Wallet listing with Pera's current first-party security documentation. That documentation explicitly states that Pera Wallet undergoes yearly security audits covering its mobile apps, API, and server infrastructure.

## Qualification and overlap

- Public USDC/USDT database bounty: https://github.com/Chain-Love/chain-love/discussions/41
- Eligible network: Algorand
- Fresh inventory of every open PR file list found no other open PR modifying `listings/specific-networks/algorand/wallets.csv`
- One CSV / one newly populated cell; expected reward is **0.06 USDC**, subject to maintainer approval

## Primary evidence

- Pera Wallet security measures: https://support.perawallet.app/en/article/pera-web-wallet-security-measures-comparison-with-myalgo-1x4qx4v/

## Validation

- canonical `validate_csv.py` — passed
- canonical `csv_to_json.py` — completed; only pre-existing missing-chain warnings
- `git diff --check` — passed
- full `validate.py` was also exercised, but the current `json-tools` schema expects `schemaVersion=2.0.0` while every generated main-branch network artifact declares the baseline `1.0.0`; this repository-wide branch mismatch is unrelated to the one-cell CSV change

## AI assistance disclosure

Implemented with Codex assistance and checked against the current first-party Pera Wallet documentation and Chain.Love style guide.

## Reward address

Ethereum mainnet USDC/USDT: `0xC49e5374F0072abC0b4c134B2fd413d87aA6354A`

Related bounty program: #41 (Discussion)