### PR TITLE
data(somnia): update ethers release metadata

### DIFF
--- a/listings/specific-networks/somnia/sdks.csv
+++ b/listings/specific-networks/somnia/sdks.csv
@@ -1,7 +1,7 @@
 slug,provider,offer,actionButtons,toolType,programmingLanguage,tag,description,planType,planName,price,trial,starred,dependencies,latestKnownVersion,latestKnownReleaseDate,maintainer,license
 alloy,,!offer:alloy,,,,,,,,,,,,,,,
 ens-js,,!offer:ens-js,,,,,,,,,,,,,,,
-ethers-js,,!offer:ethers-js,,,,,,,,,,,,,,,
+ethers-js,,!offer:ethers-js,,,,,,,,,,,,6.17.0,2026-06-18,,
 foundry,,!offer:foundry,"[""[Docs](https://docs.somnia.network/developer/development-frameworks/deploy-with-foundry)""]",,,,,,,,,,,,,,
 hardhat,,!offer:hardhat,,,,,,,,,,,,,,,
 nethereum,,!offer:nethereum,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

- populate the latest known Ethers.js release version for the existing Somnia SDK row
- populate its registry publication date

## Source evidence

The first-party npm registry metadata for `ethers` reports the `latest` dist-tag as `6.17.0` and records that version at `2026-06-18T04:48:27.802Z`:
https://registry.npmjs.org/ethers

## Validation

- CSV shape: all rows retain the 18-column schema
- `git diff --check`
- only `listings/specific-networks/somnia/sdks.csv` changed

Public reward address: `0xa600bD74CB55958A79B535b4741fD66681Fc3e8c`