### PR TITLE
data(ethereum): add Chainlink Sepolia feed

### DIFF
--- a/listings/specific-networks/ethereum/oracles.csv
+++ b/listings/specific-networks/ethereum/oracles.csv
@@ -2,6 +2,7 @@ slug,provider,offer,actionButtons,chain,technology,starred,availableApis,monitor
 api3-mainnet,,!offer:api3,"[""[Docs](https://docs.api3.org/)""]",mainnet,,,,,,,,,,,,
 band-mainnet,,!offer:band,"[""[Docs](https://docs.bandchain.org/)""]",mainnet,,,,,,,,,,,,
 chainlink-mainnet,,!offer:chainlink,"[""[ETH/USD](https://data.chain.link/feeds/ethereum/mainnet/eth-usd)""]",mainnet,,,,,,,,,,,,
+chainlink-sepolia,,!offer:chainlink,"[""[ETH/USD](https://github.com/smartcontractkit/documentation/blob/dd8d24664dfb2c489ee9cdc441a0670f5b671788/public/samples/DataFeeds/HistoricalDataConsumer.sol)""]",sepolia,,,,,,"[""ETH/USD""]",,,,,,
 chronicle-mainnet,,!offer:chronicle,"[""[ETH/USD](https://chroniclelabs.org/dashboard/oracle/ETH/USD)""]",mainnet,,,,,,,,,,,,
 chronicle-sepolia,,!offer:chronicle,"[""[SEP/USD](https://chroniclelabs.org/dashboard/oracle/ETH/USD#testnet=true&txn=0x395d4ceb7506e27e2227417719ca5c21e1baa9e3f5521a20e411ccb25f70bed9&contract=0xdd6D76262Fd7BdDe428dcfCd94386EbAe0151603&blockchain=SEP)""]",sepolia,,,,,,,,,,,,
 dia-mainnet,,!offer:dia,"[""[Website](https://www.diadata.org/)"",""[Docs](https://www.diadata.org/docs/guides/chain-specific-guide/ethereum)""]",mainnet,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

- add the missing Chainlink oracle listing for Ethereum Sepolia
- record the live ETH/USD feed documented by Chainlink

## Verification

Chainlink's current official documentation repository identifies the Sepolia ETH/USD aggregator and its deployed address (`0x694AA1769357215DE4FAC081bf1f309aDC325306`):

https://github.com/smartcontractkit/documentation/blob/dd8d24664dfb2c489ee9cdc441a0670f5b671788/public/samples/DataFeeds/HistoricalDataConsumer.sol

The Oracles category guide says to add a provider when it has live feeds/contracts or official support for the chain:

https://github.com/Chain-Love/chain-love/wiki/Oracles

I checked the currently open pull requests and found no Chainlink/Ethereum Sepolia oracle contribution.

## Reward address

`0x6873673489a0f4743c014c5c9c8664e33140Ce3D`
