### PR TITLE
data(algorand): add Pinata storage evidence

### DIFF
--- a/listings/specific-networks/algorand/storages.csv
+++ b/listings/specific-networks/algorand/storages.csv
@@ -1,4 +1,4 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planType,planName,description,starred
-pinata-fiesta,,!offer:pinata-fiesta,,,,,,,,
-pinata-free,,!offer:pinata-free,,,,,,,,
-pinata-picnic,,!offer:pinata-picnic,,,,,,,,
+pinata-fiesta,,!offer:pinata-fiesta,"[""[Algorand Docs](https://dev.algorand.co/algokit/cli/tasks/ipfs/)""]",,,,,,,
+pinata-free,,!offer:pinata-free,"[""[Algorand Docs](https://dev.algorand.co/algokit/cli/tasks/ipfs/)""]",,,,,,,
+pinata-picnic,,!offer:pinata-picnic,"[""[Algorand Docs](https://dev.algorand.co/algokit/cli/tasks/ipfs/)""]",,,,,,,


### PR DESCRIPTION
## Summary

Add Algorand-specific first-party documentation to the three existing Pinata storage plan listings.

Algorand's current AlgoKit IPFS task explicitly uses Pinata as its IPFS provider. This PR keeps the existing canonical `!offer:` references and only fills the network-specific `actionButtons` cells.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [x] Documentation/metadata only

## Scope

- Networks affected: Algorand
- Categories affected: storages
- Improved non-null cells: 3

## Verification

Primary source:
- Algorand Developer Portal — AlgoKit Task IPFS:
  https://dev.algorand.co/algokit/cli/tasks/ipfs/

The documentation states that AlgoKit's IPFS feature uses the Pinata provider for file uploads.

## Validation

- Confirmed no open PR overlaps the Algorand Pinata storage rows.
- Reused the existing canonical `!offer:pinata-*` references.
- CSV shape validated: header and all changed rows contain 11 columns.
- Diff is limited to three `actionButtons` cells in one file.

## Optional

- Rewards address (Ethereum Mainnet USDC/USDT): `0xf035e4f3f6fece500d6a89e4d2d38dac79b78334`
- Twitter (X) post link: N/A

## AI assistance disclosure

Prepared with AI assistance. The current bounty scope, repository overlap, existing canonical offers, and first-party Algorand documentation were checked before making the patch.