### PR TITLE
data(filecoin/bridges): add Hyperlane on Filecoin mainnet

### DIFF
--- a/listings/specific-networks/filecoin/bridges.csv
+++ b/listings/specific-networks/filecoin/bridges.csv
@@ -2,6 +2,7 @@ slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,open
 axelar-mainnet,,!offer:axelar,"[""[Bridge](https://app.squidrouter.com/?chains=314)"",""[Filecoin Cross-Chain Docs](https://docs.filecoin.io/smart-contracts/advanced/cross-chain-bridges)""]",mainnet,,,,,,FALSE,,,,,,,,,,,,
 celer-mainnet,,!offer:celer,"[""[Celer cBridge App](https://cbridge.celer.network/314/1/USDC)"",""[Docs](https://cbridge-docs.celer.network/reference/faq)""]",mainnet,,,,,,FALSE,,,,,,,,,,,,
 chainsafe-filecoin-testnet,,!offer:chainsafe-filecoin,,testnet,,,,,,,,,,,,,,,,,,
+hyperlane-mainnet,,!offer:hyperlane,"[""[Bridge](https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains/filecoin)"",""[Docs](https://docs.hyperlane.xyz/)""]",mainnet,,,,,,,,,,,,,,,,,,
 okutrade-mainnet,,!offer:okutrade,"[""[Bridge](https://oku.trade/bridge/filecoin)"",""[Docs](https://docs.oku.trade/home/extra-information/deployed-contracts)""]",mainnet,,,,,,,,,,,,,,,,,,
 rubic-mainnet,,!offer:rubic,,mainnet,,,,,,,,,,,,,,,,,,
 squid-mainnet,,!offer:squid,"[""[Bridge](https://app.squidrouter.com/?chains=314)"",""[Docs](https://docs.filecoin.io/build-on-filecoin/advanced/cross-chain-bridges)""]",mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds one missing row to `listings/specific-networks/filecoin/bridges.csv`: **Hyperlane** on Filecoin mainnet.

## Why this row belongs

Filecoin is a first-party supported chain in Hyperlane's own canonical registry, not a third-party
claim. `hyperlane-registry/chains/filecoin/metadata.yaml` declares:

| field | value |
|---|---|
| `name` | `filecoin` |
| `displayName` | `Filecoin` |
| `chainId` | `314` |
| `domainId` | `314` |
| `gasCurrencyCoinGeckoId` | `filecoin` |
| `blockExplorers[0]` | Filecoin VM Explorer — `https://filecoin.blockscout.com` (family `blockscout`) |

Sources (both verified reachable):

- Registry chain entry: https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains/filecoin
- Hyperlane docs: https://docs.hyperlane.xyz/

## Row shape

Follows the existing rows in the same file (`axelar-mainnet`, `okutrade-mainnet`, `squid-mainnet`):
slug `<offer>-mainnet`, `offer` as `!offer:hyperlane`, `chain` = `mainnet`, `actionButtons` carrying a
link to the chain entry plus the provider docs. Every other column is left empty rather than guessed —
no value is filled that I could not source first-party.

Verified locally against this repo's own gateway before opening: `validate_csv.py`, `csv_to_json.py`
and `validate.py` all pass, with `filecoin.json` regenerating cleanly.

---

Reward address (per the [database population bounty program](https://github.com/Chain-Love/chain-love/discussions/41)): `0x38f94aA2aEdCD31a66B2BB1ddb0eA6919039596a`
