### PR TITLE
Add Algorand Kudelski security coverage

### DIFF
--- a/listings/specific-networks/algorand/security.csv
+++ b/listings/specific-networks/algorand/security.csv
@@ -1,6 +1,7 @@
 slug,provider,offer,actionButtons,tag,description,planType,planName,price,trial,starred,toolType,deliveryType,executionEnvironment,coverage,compliance
 hacken-blockchain-protocol-audit,,!offer:hacken-blockchain-protocol-audit,,,,,,,,,,,,,
 hacken-smart-contract-audit,,!offer:hacken-smart-contract-audit,,,,,,,,,,,,,
-kudelski-architecture-review,,!offer:kudelski-architecture-review,,,,,,,,,,,,,
-kudelski-smart-contract-secure-code-review,,!offer:kudelski-smart-contract-secure-code-review,,,,,,,,,,,"AVM, TEAL",,
+kudelski-architecture-review,,!offer:kudelski-architecture-review,,,,,,,,,,,"Algorand, TEAL, PyTeal",,
+kudelski-implementation-review,,!offer:kudelski-implementation-review,,,,,,,,,,,"Algorand, TEAL, PyTeal",,
+kudelski-smart-contract-secure-code-review,,!offer:kudelski-smart-contract-secure-code-review,,,,,,,,,,,"AVM, TEAL, PyTeal",,
 ziion-linux-distro,,!offer:ziion-linux-distro,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- Add Kudelski Implementation Review as an Algorand security listing.
- Fill Algorand-specific execution environment metadata for existing Kudelski Architecture Review and Smart Contract Secure Code Review listings.

## Sources
- Kudelski Security blockchain report archive exposes filters for Algorand, Teal, PyTeal, Architecture Review, Implementation Review, and Smart Contract Secure Code Review: https://kudelskisecurity.com/blockchain
- Chain.Love Style Guide followed: listings use canonical `!offer:` references, A-Z slug order, and source-backed network support.

## Validation
- CSV imports with 6 rows and expected headers.
- Slugs are A-Z sorted.
- No duplicate slugs within `listings/specific-networks/algorand/security.csv`.
- No duplicate slugs against `listings/all-networks/security.csv`.
- All `!offer:` references resolve in `references/offers/security.csv`.

Reward address: `0x7a1689d1e167ba9e992493be0bcbf05a8dc26c9d`