### PR TITLE
feat(schema): support provider aliases and collision validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ However, schema/meta changes in this branch must be mirrored in data tables on `
     - `$defs.providerMeta`: JSON Schema for one object under generated `meta.providers[<providerSlug>]` (provider profile shown in the UI). Field meanings and CSV formatting rules (for example `logoPath`, `website` vs social handles) are documented in the data repo: [references/README.md](https://github.com/Chain-Love/chain-love/blob/main/references/README.md).
       When you change provider data shape, update this schema accordingly:
       - `properties` **columns**: if you add/remove/rename columns in `references/providers/providers.csv`, reflect the same keys/types in `providerMeta.properties` and `providerMeta.required`, and keep generated `meta.providers` consistent.
+      - `aliases` is an optional array of documented former or alternate official names. Provider search and duplicate detection should match `slug`, `name`, and every alias using case- and punctuation-insensitive comparison.
       - `categories` is a non-empty, unique array of category keys. Allowed values are enforced by `categories.items.enum` in `tools/schema.json` (see `providerMeta.properties.categories`). Whenever you add or remove an infrastructure category, update that enum so provider `categories` stays aligned with the category set used elsewhere in the schema.
 
 - **`meta/categories.json`**

--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -522,15 +522,32 @@ def load_json_file(path: str) -> dict:
         return json.load(f)
 
 
+def normalize_provider_identity(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return "".join(ch for ch in normalized if ch.isalnum())
+
+
 def build_provider_index_by_name(providers: list[dict]) -> dict[str, dict]:
     idx = {}
     for p in providers:
-        name = p.get("name")
-        if not isinstance(name, str) or not name.strip():
+        identity_values = [p.get("slug"), p.get("name"), *(p.get("aliases") or [])]
+        identities = set()
+        for value in identity_values:
+            if not isinstance(value, str) or not value.strip():
+                continue
+            identities.add(value.strip())
+            normalized = normalize_provider_identity(value)
+            if normalized:
+                identities.add(normalized)
+
+        if not identities:
             continue
-        if name in idx:
-            raise ValueError(f"Duplicate provider name in providers.csv: '{name}'")
-        idx[name] = p
+
+        for identity in identities:
+            previous = idx.get(identity)
+            if previous is not None and previous is not p:
+                raise ValueError(f"Duplicate provider identity in providers.csv: '{identity}'")
+            idx[identity] = p
     return idx
 
 
@@ -556,7 +573,7 @@ def build_provider_meta_from_names(
     meta = {}
 
     for name, categories in provider_categories.items():
-        p = provider_by_name.get(name)
+        p = provider_by_name.get(name) or provider_by_name.get(normalize_provider_identity(name))
 
         categories_list = sorted(categories)
 
@@ -571,7 +588,8 @@ def build_provider_meta_from_names(
 
             meta[slug] = {
                 "slug": slug,
-                "name": name,
+                "name": p.get("name") or name,
+                "aliases": p.get("aliases"),
                 "logoPath": p.get("logoPath"),
                 "description": p.get("description"),
                 "website": p.get("website"),

--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -586,6 +586,15 @@ def build_provider_meta_from_names(
             if not isinstance(starred, bool):
                 starred = False
 
+            # Multiple listing values (for example the current provider name and
+            # one of its aliases) can resolve to the same canonical provider.
+            # Preserve every category instead of replacing the previous entry.
+            if slug in meta:
+                meta[slug]["categories"] = sorted(
+                    set(meta[slug]["categories"]) | set(categories)
+                )
+                continue
+
             meta[slug] = {
                 "slug": slug,
                 "name": p.get("name") or name,

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -1035,6 +1035,10 @@
       "properties": {
         "slug": { "type": "string" },
         "name": { "type": "string" },
+        "aliases": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
         "logoPath": { "type": ["string", "null"] },
         "description": { "type": ["string", "null"] },
         "website": { "type": ["string", "null"] },

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -3,6 +3,8 @@ from typing import Iterator, Callable, List, Dict
 import os
 import csv
 import re
+import json
+import unicodedata
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
 
@@ -78,6 +80,72 @@ def rule_links_must_be_quoted(path: Path, rows: List[Dict[str, str]]) -> List[st
 
     return errors
 
+def normalize_identity(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return "".join(ch for ch in normalized if ch.isalnum())
+
+def rule_provider_aliases(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    """Validate provider aliases and reject ambiguous identity matches."""
+    if not path.as_posix().lower().endswith("references/providers/providers.csv"):
+        return []
+
+    errors: List[str] = []
+    identities: Dict[str, tuple[str, int]] = {}
+
+    for row_number, row in enumerate(rows, start=2):
+        slug = (row.get("slug") or "").strip()
+        name = (row.get("name") or "").strip()
+        raw_aliases = (row.get("aliases") or "").strip()
+        aliases: list[str] = []
+
+        if raw_aliases and raw_aliases.casefold() != "null":
+            try:
+                parsed = json.loads(raw_aliases)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{path}: row {row_number}: aliases must be a JSON array or NULL ({exc.msg})")
+                continue
+            if not isinstance(parsed, list) or any(not isinstance(alias, str) or not alias.strip() for alias in parsed):
+                errors.append(f"{path}: row {row_number}: aliases must be a JSON array of non-empty strings")
+                continue
+            aliases = [alias.strip() for alias in parsed]
+
+        own_identities = {identity for identity in (normalize_identity(slug), normalize_identity(name)) if identity}
+        seen_aliases: set[str] = set()
+
+        for alias in aliases:
+            identity = normalize_identity(alias)
+            if not identity:
+                errors.append(f"{path}: row {row_number}: alias '{alias}' has no searchable characters")
+                continue
+            if identity in own_identities:
+                errors.append(f"{path}: row {row_number}: alias '{alias}' duplicates this provider's name or slug")
+            if identity in seen_aliases:
+                errors.append(f"{path}: row {row_number}: alias '{alias}' duplicates another alias on the same provider")
+            seen_aliases.add(identity)
+
+        for identity in own_identities:
+            previous = identities.get(identity)
+            if previous and previous[0] != slug:
+                errors.append(
+                    f"{path}: row {row_number}: provider identity duplicates row {previous[1]} after case/punctuation normalization"
+                )
+            else:
+                identities[identity] = (slug, row_number)
+
+        for alias in aliases:
+            identity = normalize_identity(alias)
+            if not identity:
+                continue
+            previous = identities.get(identity)
+            if previous and previous[0] != slug:
+                errors.append(
+                    f"{path}: row {row_number}: alias '{alias}' conflicts with provider identity on row {previous[1]}"
+                )
+            else:
+                identities[identity] = (slug, row_number)
+
+    return errors
+
 def iter_csv_files(root: Path) -> Iterator[Path]:
     for dirpath, _, filenames in os.walk(root):
         for name in sorted(filenames):
@@ -89,6 +157,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_provider_aliases)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

Implements the tooling, schema, validation, and provider-matching portion of [DBIP #2791](https://github.com/Chain-Love/chain-love/issues/2791). The companion data and documentation changes are in #2886.

## Changes

- Adds nullable `aliases` metadata to the provider schema.
- Includes aliases in generated `meta.providers` JSON.
- Resolves provider references through canonical slugs, names, and aliases.
- Rejects case- and punctuation-insensitive identity collisions.
- Rejects malformed, empty, self-duplicated, and cross-provider aliases.
- Preserves the union of categories when listings reference the same provider by name, slug, or alias.
- Documents the new field in the json-tools guide.

## Validation

Validated this head together with companion PR #2886:

- `validate_csv.py` — passed on the full data repository.
- `csv_to_json.py` — passed and generated every network artifact.
- `validate.py` — passed for every generated JSON file.
- Focused regression: name + alias + slug references resolve to one provider with all categories preserved.
- Focused collision cases for case and punctuation variants passed.

Part of #2791; companion PR: #2886.