### PR TITLE
data(somnia): add official Testnet Hub faucet links

### DIFF
--- a/listings/specific-networks/somnia/faucets.csv
+++ b/listings/specific-networks/somnia/faucets.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,price,starred,requiredMainnetBalance,dripLimitAmount,dripLimitPeriod,additionalNotes,tag
 google-cloud-faucet,,!offer:google-cloud-faucet,"[""[Faucet](https://cloud.google.com/application/web3/faucet/somnia/shannon)""]",testnet,,,,,,1 STT,,,
-somnia-faucet-testnet,,!offer:somnia-faucet,,testnet,,,,,,,,,
+somnia-faucet-testnet,,!offer:somnia-faucet,"[""[Faucet](https://testnet.somnia.network/)"",""[Docs](https://docs.somnia.network/developer/network-info)""]",testnet,,,,,,,,,
 stakely-faucet-mainnet,,!offer:stakely-faucet,"[""[Faucet](https://stakely.io/faucet/somnia-somi)""]",mainnet,,,,,,0.001 SOMI,,,
 stakely-faucet-testnet,,!offer:stakely-faucet,"[""[Faucet](https://stakely.io/faucet/somnia-testnet-stt)""]",testnet,,,,,,0.001 STT,,,
 thirdweb-faucet,,!offer:thirdweb-faucet,"[""[Faucet](https://thirdweb.com/somnia-shannon-testnet)""]",testnet,FALSE,TRUE,$5/$99/$499/$1499,FALSE,,,,"[""Available only on paid plans""]",


### PR DESCRIPTION
## Summary

Fill the empty Somnia `somnia-faucet-testnet` `actionButtons` cell with the same first-party Faucet and Docs URLs already present on the canonical `!offer:somnia-faucet` row (Somnia Testnet Hub and Network Info docs).

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [x] Documentation/metadata only

## Scope

- Networks affected: Somnia
- Categories affected: faucets
- Improved non-null cells: 1

## Verification

Both added URLs returned HTTP 200:

- https://testnet.somnia.network/
- https://docs.somnia.network/developer/network-info

## Validation

- Confirmed no open PR currently edits `listings/specific-networks/somnia/faucets.csv`.
- Reused existing canonical `!offer:` reference.
- Local `git-hooks/pre-commit.py` passed.
- Diff is limited to one `actionButtons` cell.

## Optional

- Rewards address (Ethereum Mainnet USDC/USDT): `0xf035e4f3f6fece500d6a89e4d2d38dac79b78334`
- Twitter (X) post link: N/A

## AI assistance disclosure

Prepared with AI assistance. Current bounty eligibility (Algorand/Filecoin/Somnia only), open-PR overlap, and canonical offer URLs were checked before the patch.

Made with [Cursor](https://cursor.com)