### PR TITLE
data(somnia): add Hyperlane bridge registry links

### DIFF
--- a/listings/specific-networks/somnia/bridges.csv
+++ b/listings/specific-networks/somnia/bridges.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
-hyperlane-mainnet,,!offer:hyperlane,,mainnet,,,,,,,,,,,,,,,,,,
-hyperlane-testnet,,!offer:hyperlane,,testnet,,,,,,,,,,,,,,,,,,
+hyperlane-mainnet,,!offer:hyperlane,"[""[Bridge](https://www.hyperlane.xyz/)"",""[Registry](https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains/somnia)""]",mainnet,,,,,,,,,,,,,,,,,,
+hyperlane-testnet,,!offer:hyperlane,"[""[Bridge](https://www.hyperlane.xyz/)"",""[Registry](https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains/somniatestnet)""]",testnet,,,,,,,,,,,,,,,,,,
 jumper-mainnet,,!offer:jumper,"[""[Bridge](https://jumper.xyz/)"",""[Integration](https://blog.somnia.network/p/somnia-integrates-with-lifi-to-expand)""]",mainnet,,,,,,,,,,,,,,,,,,
 lifi-mainnet,,!offer:lifi,"[""[Website](https://li.fi)"",""[Integration](https://blog.somnia.network/p/somnia-integrates-with-lifi-to-expand)""]",mainnet,,,,,,,,,,,,,,,,,,
 relay-mainnet,,!offer:relay,,mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Fill empty Somnia Hyperlane mainnet and testnet `actionButtons` cells with:

- Hyperlane Bridge homepage (same canonical offer link)
- Hyperlane registry chain metadata for Somnia mainnet (`chains/somnia`, domain/chainId 5031) and Somnia Testnet (`chains/somniatestnet`, chainId 50312)

This mirrors the existing Jumper/LI.FI pattern of a product link plus Somnia-specific evidence. Open PR #2813 only edits the Hyperlane `supportedChains` offer field and does not touch this listing file.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [x] Documentation/metadata only

## Scope

- Networks affected: Somnia
- Categories affected: bridges
- Improved non-null cells: 2

## Verification

All cited URLs returned HTTP 200:

- https://www.hyperlane.xyz/
- https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains/somnia
- https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains/somniatestnet
- Registry metadata names Somnia / Somnia Testnet with explorers and RPCs

## Validation

- Confirmed no open PR currently edits `listings/specific-networks/somnia/bridges.csv`.
- Reused existing canonical `!offer:hyperlane`.
- Local `git-hooks/pre-commit.py` passed.
- Diff is limited to two `actionButtons` cells.

## Optional

- Rewards address (Ethereum Mainnet USDC/USDT): `0xf035e4f3f6fece500d6a89e4d2d38dac79b78334`
- Twitter (X) post link: N/A

## AI assistance disclosure

Prepared with AI assistance. Current bounty eligibility, open-PR overlap, and Hyperlane registry Somnia evidence were checked before the patch.

Made with [Cursor](https://cursor.com)