### PR TITLE
data(algorand): add Messina bridge actionButtons

### DIFF
--- a/listings/specific-networks/algorand/bridges.csv
+++ b/listings/specific-networks/algorand/bridges.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
 allbridge,,!offer:allbridge-core,"[""[Bridge](https://core.allbridge.io/)"",""[Docs](https://docs-core.allbridge.io/sdk/guides/algorand)""]",mainnet,,,,,,,,,,,,,,,,,,
-messina,,!offer:messina,,mainnet,,,,,,,,,,,,,,,,,,
+messina,,!offer:messina,"[""[Bridge](https://messina.one/bridge)"",""[Docs](https://messinaone.gitbook.io/messina/)""]",mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Fill the empty Algorand Messina bridge `actionButtons` cell with first-party Messina bridge and docs links. The Messina bridge UI currently lists Algorand as a source chain.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [x] Documentation/metadata only

## Scope

- Networks affected: Algorand
- Categories affected: bridges
- Improved non-null cells: 1

## Verification

All added URLs returned HTTP 200:

- Messina bridge UI (lists Algorand): https://messina.one/bridge
- Messina docs: https://messinaone.gitbook.io/messina/

## Validation

- Confirmed no open PR currently edits `listings/specific-networks/algorand/bridges.csv`.
- Reused the existing `!offer:messina` reference.
- Diff is limited to one `actionButtons` cell.

## Optional

- Rewards address (Ethereum Mainnet USDC/USDT): `0xf035e4f3f6fece500d6a89e4d2d38dac79b78334`
- Twitter (X) post link: N/A

## AI assistance disclosure

Prepared with AI assistance. Current bounty eligibility, open-PR overlap, and first-party Messina Algorand evidence were checked before the patch.


Made with [Cursor](https://cursor.com)