### PR TITLE
feat(somnia): add goldsky-docs-mcp listing

### DIFF
--- a/listings/specific-networks/somnia/mcpservers.csv
+++ b/listings/specific-networks/somnia/mcpservers.csv
@@ -1,3 +1,4 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
 coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,,,,,
+goldsky-docs-mcp,,!offer:goldsky-docs-mcp,,,,,,,,,,,,,,,,,,,,
 wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Adds the source-verified Goldsky MCP server listing for Somnia.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: Somnia
- Categories affected: mcpservers
- Additional notes: 1 listing row, 3 non-empty cells. Network support verified against Goldsky's own supported-networks docs (https://docs.goldsky.com/chains/supported-networks — lists Somnia Testnet). Canonical offer ref `!offer:goldsky-docs-mcp` already exists in `references/offers/mcpservers.csv` (provider Goldsky, hosted docs + API-reference MCP at https://docs.goldsky.com/mcp).

Payout address: 0xBc14D9C1E2202E3385e7FE89D5d65D42c90ECaB8
