### PR TITLE
Add CertiK security audit for Algorand

### DIFF
--- a/listings/specific-networks/algorand/security.csv
+++ b/listings/specific-networks/algorand/security.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,tag,description,planType,planName,price,trial,starred,toolType,deliveryType,executionEnvironment,coverage,compliance
+certik,,!offer:certik,,,,,,,,,,,,,
 hacken-blockchain-protocol-audit,,!offer:hacken-blockchain-protocol-audit,,,,,,,,,,,,,
 hacken-smart-contract-audit,,!offer:hacken-smart-contract-audit,,,,,,,,,,,,,
 kudelski-architecture-review,,!offer:kudelski-architecture-review,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Adds the source-verified CertiK security listing for Algorand.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: Algorand
- Categories affected: security
- Additional notes: 1 listing row (listings/specific-networks/algorand/security.csv), 1 non-empty cell. Network support verified against CertiK's official Algorand ecosystem page (https://www.certik.com/ecosystems/algorand — 'Security audit for the Algorand ecosystem', naming Algorand projects audited incl. Folks Finance, ICON Network, WazirX, Orion Protocol). Canonical offer ref `!offer:certik` already exists in references/offers/security.csv.

Payout address: 0xBc14D9C1E2202E3385e7FE89D5d65D42c90ECaB8
