### PR TITLE
data(filecoin): add 4EVERLAND and Spheron platform links

### DIFF
--- a/listings/specific-networks/filecoin/platforms.csv
+++ b/listings/specific-networks/filecoin/platforms.csv
@@ -1,7 +1,7 @@
 slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
-4everland-free,,!offer:4everland-free,,,,,,,,,,
-4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,,,,,,,,,,
+4everland-free,,!offer:4everland-free,"[""[Website](https://www.4everland.org/)""]",,,,,,,,,
+4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,"[""[Docs](https://docs.4everland.org/get-started/billing-and-pricing/pricing-model)""]",,,,,,,,,
 apeworx,,!offer:apeworx,,,,,,,,,,
 portal-developer,,!offer:portal-developer,,,,,,,,,,
 portal-startup,,!offer:portal-startup,,,,,,,,,,
-spheron-network,,!offer:spheron-network,,,,,,,,,,
+spheron-network,,!offer:spheron-network,"[""[Website](https://www.spheron.network)""]",,,,,,,,,


### PR DESCRIPTION
## Summary

Fill empty Filecoin platform listing `actionButtons` cells from the canonical first-party links already present on the matching offer rows for 4EVERLAND and Spheron Network.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [x] Documentation/metadata only

## Scope

- Networks affected: Filecoin
- Categories affected: platforms
- Improved non-null cells: 3

## Verification

Links are copied from existing offer rows and were previously reachable (4EVERLAND website/docs and Spheron website).

## Validation

- No open PR currently edits `listings/specific-networks/filecoin/platforms.csv`.
- Skipped Portal (Amoy/Polygon-oriented) and ApeWorx (generic EVM tooling) to avoid weak network evidence.
- Diff is limited to three `actionButtons` cells.

## Optional

- Rewards address (Ethereum Mainnet USDC/USDT): `0xf035e4f3f6fece500d6a89e4d2d38dac79b78334`
- Twitter (X) post link: N/A

## AI assistance disclosure

Prepared with AI assistance. Current bounty eligibility, open-PR overlap, and canonical offer rows were checked before the patch.


Made with [Cursor](https://cursor.com)