### PR TITLE
Add Akave Standard to Filecoin storage listings

### DIFF
--- a/listings/specific-networks/filecoin/storages.csv
+++ b/listings/specific-networks/filecoin/storages.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planType,planName,description,starred
+akave-cloud-standard,,!offer:akave-cloud-standard,,,,,,,,
 filebase-free,,!offer:filebase-free,,,,,,,,
 filebase-pay-as-you-go,,!offer:filebase-pay-as-you-go,,,,,,,,
 filecoin-onchain-cloud-warm-storage,,!offer:filecoin-onchain-cloud-warm-storage,,,,,,,,


### PR DESCRIPTION
## Summary
- add the existing canonical `akave-cloud-standard` offer to Filecoin storage listings
- reuse the reference row instead of duplicating pricing or product metadata

## Verification
- Akave's official announcement states that Cloud Standard is a Filecoin-powered storage tier and that the Filecoin PDP integration is active on testnet
- the canonical offer already identifies the Standard tier as Filecoin-backed and links official pricing/docs
- CSV parses, remains slug-sorted, the reference resolves exactly once, and `git diff --check` passes

Official source: https://akave.com/blog/akave-cloud-now-offers-verifiable-backup-storage-powered-by-filecoin-onchain-cloud

## Checklist
- [x] I read and followed `AGENTS.md`, `CONTRIBUTING.md`, the Style Guide, and Column Definitions.
- [x] I personally verified the provider currently supports the adjusted network.
- [x] I reused the canonical offer reference rather than duplicating data.
- [x] This PR changes one row in one network/category file.

Rewards address: `0x215bd7cB62D8288a365e5AF372E695eF44aBd071`

AI disclosure: AI-assisted repository analysis was used; the source claim and final diff were manually verified.