### PR TITLE
Add compute category metadata and schema (#2625)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,17 +10,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      
+
       - name: Install dependencies
+        working-directory: tools
         run: pip install --upgrade pip && pip install -r requirements.txt
 
       - name: Run CSV to JSON
+        working-directory: tools
         run: python3 csv_to_json.py
 
       - name: Run validation script
+        working-directory: tools
         run: python validate.py

--- a/meta/categories.json
+++ b/meta/categories.json
@@ -66,6 +66,12 @@
     "icon": "lucide:ChartNetwork",
     "description": "Development platforms, tools, and services for developers."
   },
+  "compute": {
+    "key": "compute",
+    "label": "Compute",
+    "icon": "lucide:Cpu",
+    "description": "CPU/GPU execution infrastructure for AI, rendering, batch, scientific, and general compute workloads."
+  },
   "sdks": {
     "key": "sdks",
     "label": "SDKs",

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -1262,5 +1262,71 @@
     "sorting": "string",
     "pinning": null,
     "cellType": null
+  },
+  "resourceTypes": {
+    "key": "resourceTypes",
+    "label": "Resource Types",
+    "icon": "lucide:Cpu",
+    "description": "Compute resource classes offered (CPU, GPU, accelerator).",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "provisioningMode": {
+    "key": "provisioningMode",
+    "label": "Provisioning Mode",
+    "icon": "lucide:CloudCog",
+    "description": "How compute capacity is provisioned (container, VM, bare metal, serverless, marketplace, or mixed).",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "technicalDetails"
+  },
+  "workloadTypes": {
+    "key": "workloadTypes",
+    "label": "Workload Types",
+    "icon": "lucide:BrainCircuit",
+    "description": "Primary workloads supported by the compute offer.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "interfaces": {
+    "key": "interfaces",
+    "label": "Interfaces",
+    "icon": "lucide:Terminal",
+    "description": "Interfaces available to provision or operate compute.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "developerExperience"
+  },
+  "pricingUnit": {
+    "key": "pricingUnit",
+    "label": "Pricing Unit",
+    "icon": "lucide:BadgeDollarSign",
+    "description": "Primary billing unit or market-based pricing model.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "pricing"
+  },
+  "minimumCommitment": {
+    "key": "minimumCommitment",
+    "label": "Minimum Commitment",
+    "icon": "lucide:Clock",
+    "description": "Documented minimum usage or commitment, when applicable.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "pricing"
   }
 }

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -15,6 +15,7 @@
     "oracles": { "type": "array", "items": { "$ref": "#/$defs/oracles" } },
     "bridges": { "type": "array", "items": { "$ref": "#/$defs/bridges" } },
     "services": { "type": "array", "items": { "$ref": "#/$defs/services" } },
+    "compute": { "type": "array", "items": { "$ref": "#/$defs/compute" } },
     "storages": { "type": "array", "items": { "$ref": "#/$defs/storages" } },
     "faucets": { "type": "array", "items": { "$ref": "#/$defs/faucets" } },
     "analytics": { "type": "array", "items": { "$ref": "#/$defs/analytics" } },
@@ -362,6 +363,32 @@
         "actionButtons",
         "planType"
       ]
+    },
+
+    "compute": {
+      "title": "Compute",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "slug": { "type": "string" },
+        "provider": { "type": "string" },
+        "offer": { "type": ["string", "null"] },
+        "actionButtons": { "type": ["array", "null"], "items": { "type": "string" } },
+        "tag": { "type": ["array", "null"], "items": { "type": "string" } },
+        "description": { "type": ["string", "null"] },
+        "price": { "type": ["string", "null"] },
+        "planType": { "type": "string" },
+        "planName": { "type": ["string", "null"] },
+        "starred": { "type": "boolean" },
+        "resourceTypes": { "type": "array", "items": { "type": "string", "enum": ["cpu", "gpu", "accelerator"] }, "minItems": 1, "uniqueItems": true },
+        "provisioningMode": { "type": "string", "enum": ["container", "vm", "bare_metal", "serverless", "marketplace", "mixed"] },
+        "workloadTypes": { "type": "array", "items": { "type": "string", "enum": ["general_compute", "ai_inference", "ai_training", "rendering", "batch", "scientific"] }, "minItems": 1, "uniqueItems": true },
+        "hardware": { "type": ["array", "null"], "items": { "type": "string" } },
+        "interfaces": { "type": "array", "items": { "type": "string", "enum": ["web", "api", "cli", "docker", "kubernetes", "sdk"] }, "minItems": 1, "uniqueItems": true },
+        "pricingUnit": { "type": "string", "enum": ["hour", "second", "job", "market-based"] },
+        "minimumCommitment": { "type": ["string", "null"] }
+      },
+      "required": ["slug", "provider", "actionButtons", "tag", "description", "price", "planType", "starred", "resourceTypes", "provisioningMode", "workloadTypes", "hardware", "interfaces", "pricingUnit", "minimumCommitment"]
     },
 
     "storages": {
@@ -966,6 +993,7 @@
         "wallets": { "type": "array", "items": { "type": "string" } },
         "mcpservers": { "type": "array", "items": { "type": "string" } },
         "services": { "type": "array", "items": { "type": "string" } },
+        "compute": { "type": "array", "items": { "type": "string" } },
         "ramps": { "type": "array", "items": { "type": "string" } },
         "storages": { "type": "array", "items": { "type": "string" } },
         "sdks": { "type": "array", "items": { "type": "string" } },
@@ -1060,6 +1088,7 @@
               "oracles",
               "bridges",
               "services",
+              "compute",
               "storages",
               "faucets",
               "analytics",

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -102,6 +102,10 @@ def has_unclosed_markdown(s: str) -> bool:
     if len(s) == 0:
         return False
 
+    # Technical snake_case identifiers such as bare_metal are not Markdown.
+    if re.fullmatch(r"[a-z0-9]+(?:_[a-z0-9]+)+", s):
+        return False
+
     # Pairs that must be closed: **, *, _, `, [ ]( )
     # Check bold/italic/code
     if s.count("**") % 2 != 0:


### PR DESCRIPTION
Implements the metadata/schema half of approved DBIP #2625.

This adds:
- a new `compute` category in `meta/categories.json`;
- compute-specific column metadata for resource types, provisioning mode, workload types, hardware, interfaces, pricing unit, and minimum commitment;
- a `compute` schema with the approved enum boundaries;
- `compute` in generated category column metadata and provider category enums;
- a narrow validator fix so approved snake_case enum identifiers such as `bare_metal` are not misclassified as unclosed Markdown.

The data half is already prepared on `franklincg:money-agent-2625-compute-data` with a small source-backed initial dataset for Akash Network, io.net, and Aethir. It passes `validate_csv.py`, `csv_to_json.py`, and `validate.py` when validated against this branch's metadata/schema. I will open the main-branch data PR after this metadata PR lands so normal main CI consumes the new category schema.

Related: #2625

AI disclosure: implementation assistance was provided by AI; changes follow the approved DBIP and existing `json-tools` category patterns.