### PR TITLE
feat(schema): add trading platforms category (DBIP #1848)

### DIFF
--- a/meta/categories.json
+++ b/meta/categories.json
@@ -78,6 +78,12 @@
     "icon": "lucide:LayoutGrid",
     "description": "Infrastructure platforms and stacks."
   },
+  "tradingplatforms": {
+    "key": "tradingplatforms",
+    "label": "Trading Platforms",
+    "icon": "lucide:ArrowLeftRight",
+    "description": "DEXs, CEXs, and aggregators for spot and other crypto trading."
+  },
   "security": {
     "key": "security",
     "label": "Security",

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -1253,6 +1253,50 @@
     "cellType": null,
     "group": "identity"
   },
+  "platformType": {
+    "key": "platformType",
+    "label": "Platform Type",
+    "icon": "lucide:Layers3",
+    "description": "Trading venue type, such as DEX, CEX, or aggregator.",
+    "filter": "searchableMultiSelect",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "capabilities"
+  },
+  "tradingTypes": {
+    "key": "tradingTypes",
+    "label": "Trading Types",
+    "icon": "lucide:ArrowLeftRight",
+    "description": "Trading mechanisms supported by the platform.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "kycRequired": {
+    "key": "kycRequired",
+    "label": "KYC Required",
+    "icon": "lucide:BadgeCheck",
+    "description": "Whether identity verification is mandatory for the documented trading access.",
+    "filter": "select",
+    "sorting": "boolean",
+    "pinning": null,
+    "cellType": null,
+    "group": "compliance"
+  },
+  "feeStructure": {
+    "key": "feeStructure",
+    "label": "Fee Structure",
+    "icon": "lucide:ReceiptText",
+    "description": "Documented fee model for the trading platform.",
+    "filter": null,
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "pricing"
+  },
   "registrationType": {
     "key": "registrationType",
     "label": "Registration Type",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -23,6 +23,7 @@
     "sdks": { "type": "array", "items": { "$ref": "#/$defs/sdks" } },
     "ramps": { "type": "array", "items": { "$ref": "#/$defs/ramps" } },
     "platforms": { "type": "array", "items": { "$ref": "#/$defs/platforms" } },
+    "tradingplatforms": { "type": "array", "items": { "$ref": "#/$defs/tradingplatforms" } },
     "security": { "type": "array", "items": { "$ref": "#/$defs/security" } },
     "agents": { "type": "array", "items": { "$ref": "#/$defs/agents" } },
     "columns": { "$ref": "#/$defs/columns" },
@@ -787,6 +788,39 @@
         "executionEnvironment"
       ]
     },
+    "tradingplatforms": {
+      "title": "Trading Platforms",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "slug": { "type": "string" },
+        "provider": { "type": "string" },
+        "offer": { "type": ["string", "null"] },
+        "actionButtons": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "platformType": { "type": "string", "examples": ["DEX", "CEX", "Aggregator"] },
+        "tradingTypes": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "kycRequired": { "type": ["boolean", "null"] },
+        "feeStructure": { "type": ["string", "null"] },
+        "starred": { "type": "boolean" }
+      },
+      "required": [
+        "slug",
+        "provider",
+        "offer",
+        "actionButtons",
+        "platformType",
+        "tradingTypes",
+        "kycRequired",
+        "feeStructure",
+        "starred"
+      ]
+    },
     "security": {
       "title": "Security",
       "type": "object",
@@ -970,6 +1004,7 @@
         "storages": { "type": "array", "items": { "type": "string" } },
         "sdks": { "type": "array", "items": { "type": "string" } },
         "platforms": { "type": "array", "items": { "type": "string" } },
+        "tradingplatforms": { "type": "array", "items": { "type": "string" } },
         "security": { "type": "array", "items": { "type": "string" } },
         "agents": { "type": "array", "items": { "type": "string" } }
       }
@@ -1068,6 +1103,7 @@
               "sdks",
               "ramps",
               "platforms",
+              "tradingplatforms",
               "security",
               "agents"
             ]


### PR DESCRIPTION
## Summary

Implements the schema/tooling half of approved DBIP #1848 for a `tradingplatforms` category.

- Registers `tradingplatforms` in the top-level schema, generated column map, and provider category enum.
- Defines the approved comparison fields: `platformType`, `tradingTypes`, `kycRequired`, and `feeStructure`, plus the standard identity/action/star fields.
- Adds category and column metadata for the contributor UI.
- Uses a distinct `tradingplatforms` key and explicitly recreates the stale/CI-failing #1897 attempt rather than copying its legacy `trading` table.

## Validation

- `python -m json.tool` passes for all three changed JSON files.
- Combined with the companion data checkout, `csv_to_json.py`, `validate.py`, and `validate_csv.py` pass; all current network artifacts validate against the updated schema.
- No wallet, payment, or external account action was used.

## Related work

- Approved DBIP: https://github.com/Chain-Love/chain-love/issues/1848
- Previous stale attempt: https://github.com/Chain-Love/chain-love/pull/1897
- Companion data branch: `codex/trading-platforms-data`

## Reward address

`0x215bd7cB62D8288a365e5AF372E695eF44aBd071`

## AI disclosure

Implementation was prepared with AI assistance and manually reviewed against the DBIP, repository schema patterns, and the official style guide.