### PR TITLE
fix(schema): rename economic security columns (fixes #2681)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -384,9 +384,9 @@
     "cellType": null,
     "group": "security"
   },
-  "economicalSecurity": {
-    "key": "economicalSecurity",
-    "label": "Economical Security",
+  "economicSecurity": {
+    "key": "economicSecurity",
+    "label": "Economic Security",
     "icon": "lucide:ShieldHalf",
     "description": "Provides economic security guarantees.",
     "filter": "select",
@@ -395,9 +395,9 @@
     "cellType": null,
     "group": "security"
   },
-  "economicalSecurityNote": {
-    "key": "economicalSecurityNote",
-    "label": "Economical Security Note",
+  "economicSecurityNote": {
+    "key": "economicSecurityNote",
+    "label": "Economic Security Note",
     "icon": "lucide:ShieldEllipsis",
     "description": "Notes about economic security.",
     "filter": "select",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -213,8 +213,8 @@
           "items": { "type": "string" }
         },
         "decentralizationModel": { "type": ["string", "null"] },
-        "economicalSecurity": { "type": "boolean" },
-        "economicalSecurityNote": { "type": ["string", "null"] },
+        "economicSecurity": { "type": "boolean" },
+        "economicSecurityNote": { "type": ["string", "null"] },
         "sdk": { "type": ["array", "null"], "items": { "type": "string" } },
         "auditsPerformed": {
           "type": ["array", "null"],
@@ -237,8 +237,8 @@
         "additionalFeatures",
         "dataTypes",
         "decentralizationModel",
-        "economicalSecurity",
-        "economicalSecurityNote",
+        "economicSecurity",
+        "economicSecurityNote",
         "sdk",
         "auditsPerformed",
         "actionButtons",
@@ -281,8 +281,8 @@
         "txSpeedSla": { "type": ["string", "null"] },
         "throughputSla": { "type": ["string", "null"] },
         "price": { "type": ["string", "null"] },
-        "economicalSecurity": { "type": "boolean" },
-        "economicalSecurityNote": { "type": ["string", "null"] },
+        "economicSecurity": { "type": "boolean" },
+        "economicSecurityNote": { "type": ["string", "null"] },
         "auditsPerformed": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -311,8 +311,8 @@
         "txSpeedSla",
         "throughputSla",
         "price",
-        "economicalSecurity",
-        "economicalSecurityNote",
+        "economicSecurity",
+        "economicSecurityNote",
         "auditsPerformed",
         "decentralizationModel",
         "sdk",


### PR DESCRIPTION
## Summary

Updates the coordinated json-tools schema so the approved #2681 data migration is represented consistently.

## Type of change
- [x] Schema change

## Scope
- Networks affected: global generated schema
- Categories affected: bridges and oracles
- Changes: rename economicalSecurity to economicSecurity and economicalSecurityNote to economicSecurityNote in meta/columns.json and tools/schema.json.
- This is metadata/schema-only; row values are unchanged.

## Links
- Closes #2681
- Coordinated data PR: #2969

## Validation checklist
- [x] Style Guide and Column Definitions reviewed.
- [x] The schema change matches the 219-file data rename in the coordinated PR.
- [x] JSON syntax and schema validation checks pass locally.
- [x] No providers, links, or data values were added or removed.
- [x] This is not a blind AI-generated submission: the change was scoped to the approved DBIP and reviewed against the data diff.

## Rewards address (optional)
0x215bd7cB62D8288a365e5AF372E695eF44aBd071 (Ethereum/EVM rewards address; no transaction is requested).