### PR TITLE
feat(schema): add NFT tools category

### DIFF
--- a/meta/categories.json
+++ b/meta/categories.json
@@ -78,6 +78,12 @@
     "icon": "lucide:LayoutGrid",
     "description": "Infrastructure platforms and stacks."
   },
+  "nfttools": {
+    "key": "nfttools",
+    "label": "NFT Tools",
+    "icon": "lucide:Image",
+    "description": "Developer infrastructure for creating, discovering, trading, and gating NFT assets."
+  },
   "security": {
     "key": "security",
     "label": "Security",

--- a/meta/columns.json
+++ b/meta/columns.json
@@ -1262,5 +1262,71 @@
     "sorting": "string",
     "pinning": null,
     "cellType": null
+  },
+  "nftFunctions": {
+    "key": "nftFunctions",
+    "label": "NFT Functions",
+    "icon": "lucide:Sparkles",
+    "description": "Documented NFT-oriented jobs supported by the offer, such as minting, discovery, trading, analytics, or token gating.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "deliveryTypes": {
+    "key": "deliveryTypes",
+    "label": "Delivery Types",
+    "icon": "lucide:PackageOpen",
+    "description": "Documented delivery mechanisms such as API, SDK, smart contracts, hosted app, or library.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "tokenStandards": {
+    "key": "tokenStandards",
+    "label": "Token Standards",
+    "icon": "lucide:Badge",
+    "description": "NFT token standards explicitly documented by the provider.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "technical"
+  },
+  "assetActions": {
+    "key": "assetActions",
+    "label": "Asset Actions",
+    "icon": "lucide:ArrowLeftRight",
+    "description": "Documented actions available for NFT assets, such as mint, read, transfer, list, buy, sell, bid, gate, or renew.",
+    "filter": "searchableMultiSelect",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
+  "custodyModel": {
+    "key": "custodyModel",
+    "label": "Custody Model",
+    "icon": "lucide:ShieldCheck",
+    "description": "Documented custody model for the NFT tooling: non-custodial, custodial, or mixed.",
+    "filter": "select",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "compliance"
+  },
+  "metadataSupport": {
+    "key": "metadataSupport",
+    "label": "Metadata Support",
+    "icon": "lucide:FileImage",
+    "description": "Whether the provider documents no, read, write, or read/write NFT metadata support.",
+    "filter": "select",
+    "sorting": "string",
+    "pinning": null,
+    "cellType": null,
+    "group": "capabilities"
   }
 }

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -806,23 +806,73 @@
         },
         "description": { "type": ["string", "null"] },
         "nftFunctions": {
-          "type": ["array", "null"],
-          "items": { "type": "string" }
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "examples": [
+              "minting",
+              "metadata",
+              "discovery",
+              "trading",
+              "marketplace_aggregation",
+              "analytics",
+              "token_gating",
+              "membership",
+              "royalties",
+              "portfolio"
+            ]
+          }
         },
         "deliveryTypes": {
-          "type": ["array", "null"],
-          "items": { "type": "string" }
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "examples": [
+              "api",
+              "sdk",
+              "smart_contracts",
+              "hosted_app",
+              "library",
+              "protocol"
+            ]
+          }
         },
         "tokenStandards": {
           "type": ["array", "null"],
-          "items": { "type": "string" }
+          "items": {
+            "type": "string",
+            "examples": ["ERC-721", "ERC-1155"]
+          }
         },
         "assetActions": {
           "type": ["array", "null"],
-          "items": { "type": "string" }
+          "items": {
+            "type": "string",
+            "examples": [
+              "create",
+              "mint",
+              "read",
+              "transfer",
+              "list",
+              "buy",
+              "sell",
+              "bid",
+              "burn",
+              "gate",
+              "renew"
+            ]
+          }
         },
-        "custodyModel": { "type": ["string", "null"] },
-        "metadataSupport": { "type": ["string", "null"] },
+        "custodyModel": {
+          "type": ["string", "null"],
+          "examples": ["non_custodial", "custodial", "mixed"]
+        },
+        "metadataSupport": {
+          "type": ["string", "null"],
+          "examples": ["none", "read", "write", "read_write"]
+        },
         "starred": { "type": "boolean" }
       },
       "required": [

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -23,6 +23,7 @@
     "sdks": { "type": "array", "items": { "$ref": "#/$defs/sdks" } },
     "ramps": { "type": "array", "items": { "$ref": "#/$defs/ramps" } },
     "platforms": { "type": "array", "items": { "$ref": "#/$defs/platforms" } },
+    "nfttools": { "type": "array", "items": { "$ref": "#/$defs/nfttools" } },
     "security": { "type": "array", "items": { "$ref": "#/$defs/security" } },
     "agents": { "type": "array", "items": { "$ref": "#/$defs/agents" } },
     "columns": { "$ref": "#/$defs/columns" },
@@ -787,6 +788,59 @@
         "executionEnvironment"
       ]
     },
+    "nfttools": {
+      "title": "NFT Tools",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "slug": { "type": "string" },
+        "provider": { "type": "string" },
+        "offer": { "type": ["string", "null"] },
+        "actionButtons": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "tag": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "description": { "type": ["string", "null"] },
+        "nftFunctions": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "deliveryTypes": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "tokenStandards": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "assetActions": {
+          "type": ["array", "null"],
+          "items": { "type": "string" }
+        },
+        "custodyModel": { "type": ["string", "null"] },
+        "metadataSupport": { "type": ["string", "null"] },
+        "starred": { "type": "boolean" }
+      },
+      "required": [
+        "slug",
+        "provider",
+        "offer",
+        "actionButtons",
+        "tag",
+        "description",
+        "nftFunctions",
+        "deliveryTypes",
+        "tokenStandards",
+        "assetActions",
+        "custodyModel",
+        "metadataSupport",
+        "starred"
+      ]
+    },
     "security": {
       "title": "Security",
       "type": "object",
@@ -970,6 +1024,7 @@
         "storages": { "type": "array", "items": { "type": "string" } },
         "sdks": { "type": "array", "items": { "type": "string" } },
         "platforms": { "type": "array", "items": { "type": "string" } },
+        "nfttools": { "type": "array", "items": { "type": "string" } },
         "security": { "type": "array", "items": { "type": "string" } },
         "agents": { "type": "array", "items": { "type": "string" } }
       }
@@ -1068,6 +1123,7 @@
               "sdks",
               "ramps",
               "platforms",
+              "nfttools",
               "security",
               "agents"
             ]


### PR DESCRIPTION
## Summary
Adds schema and UI metadata for the NFT developer tooling category requested by DBIP #2639.

## Scope
- Registers nfttools at the top level and in the provider category enum.
- Defines the required NFT tool fields and nullable documentation fields in tools/schema.json.
- Adds category metadata and column metadata for NFT functions, delivery types, token standards, asset actions, custody model, and metadata support.
- Companion data PR: #2971.

## Validation
- Draft 2020-12 schema self-check passed.
- Combined schema validation passed for the new offers, category metadata, column metadata, and column order.
- JSON parsing and git diff checks passed.
- AI assistance was used for drafting, followed by manual schema and source review; this is not a blind generated submission.

## Related issue and reward address
DBIP #2639: https://github.com/Chain-Love/chain-love/issues/2639
0x215bd7cB62D8288a365e5AF372E695eF44aBd071
No transaction is requested.