### PR TITLE
feat(schema): support license metadata for MCP servers

### DIFF
--- a/tools/schema.json
+++ b/tools/schema.json
@@ -613,7 +613,8 @@
         "planName": { "type": ["string", "null"] },
         "price": { "type": ["string", "null"] },
         "trial": { "type": "boolean" },
-        "starred": { "type": "boolean" }
+        "starred": { "type": "boolean" },
+        "license": { "type": ["string", "null"] }
       },
       "required": [
         "slug",
@@ -636,7 +637,8 @@
         "planType",
         "price",
         "trial",
-        "starred"
+        "starred",
+        "license"
       ]
     },
 


### PR DESCRIPTION
## Summary

Adds the license property to the MCP-server JSON schema and requires it in generated MCP-server objects. This lets the CSV-to-JSON pipeline carry the new DBIP field into the JSON arrays without duplicating license values in network listings.

## Type of change

- [ ] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [x] Schema change
- [ ] Documentation/metadata only

## Scope

- Networks affected: global JSON output
- Categories affected: MCP servers
- Additional notes: Four schema lines changed in tools/schema.json; the field accepts a string or null and is required for MCP-server objects.

## Links

- Closes #2693
- Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
- Column Definitions: https://github.com/Chain-Love/chain-love/wiki

## Validation checklist

- [x] I followed the Style Guide and Column Definitions.
- [x] No new external links or provider data were added.
- [x] The schema parses as valid JSON locally.
- [x] This contribution was assisted by GPT-5 in Codex and reviewed before submission.

## Optional

- Rewards address: 0xf04865D955D5f698951c3eBFdb6654EF5Ab17ac