### PR TITLE
data(filecoin): add verified MCP action links

### DIFF
--- a/listings/specific-networks/filecoin/mcpservers.csv
+++ b/listings/specific-networks/filecoin/mcpservers.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
-blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
-coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,,,,,
-evm-mcp-server,,!offer:evm-mcp-server,,,,,,,,,,,,,,,,,,,,
+blockscout-mcp,,!offer:blockscout-mcp,"[""[Website](https://github.com/blockscout/mcp-server)"",""[Docs](https://github.com/blockscout/mcp-server#readme)""]",,,,,,,,,,,,,,,,,,,
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,"[""[Website](https://github.com/coinbase/agentkit/tree/main/typescript/framework-extensions/model-context-protocol)"",""[Docs](https://docs.cdp.coinbase.com/agent-kit/core-concepts/model-context-protocol)""]",,,,,,,,,,,,,,,,,,,
+evm-mcp-server,,!offer:evm-mcp-server,"[""[Website](https://github.com/mcpdotdirect/evm-mcp-server)"",""[Docs](https://github.com/mcpdotdirect/evm-mcp-server#readme)""]",,,,,,,,,,,,,,,,,,,
 filecoin-onchain-cloud-mcp,,!offer:filecoin-onchain-cloud-mcp,,,,,,,,,,,,,,,,,,,,
-wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,"[""[Website](https://github.com/wallet-agent/wallet-agent)"",""[Docs](https://github.com/wallet-agent/wallet-agent#readme)""]",,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Adds canonical action buttons to four existing Filecoin MCP listings: Blockscout MCP, Coinbase AgentKit MCP, EVM MCP Server, and Wallet Agent. No rows, providers, pricing, or capability claims are added.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope

- Networks affected: Filecoin
- Categories affected: mcpservers
- Improved non-null cells: 4
- Excluded overlap: `filecoin-onchain-cloud-mcp` is already covered by open PR #2935.

## Verification

- Opened all 8 destination URLs with redirects enabled; all returned HTTP 200.
- Searched open PRs for the four retained slugs and Filecoin MCP action-button work.
- The patch changes only `actionButtons` values in one file.

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions.**
- [x] **I personally opened and verified every new link I'm adding.**
- [x] **I confirmed every value against its canonical offer row.**
- [x] **This PR is not a blind AI-generated submission.**

The complete official pre-commit workflow passed: `validate_csv.py`, `csv_to_json.py`, and `validate.py`. AI-assisted for candidate comparison; every retained URL and the final diff was manually reviewed.

## Optional

- Rewards address: `0x769f7a238c8874148bcA1aE0736295630C28faF7`
