### PR TITLE
data(algorand): add verified platform links

### DIFF
--- a/listings/specific-networks/algorand/platforms.csv
+++ b/listings/specific-networks/algorand/platforms.csv
@@ -1,4 +1,4 @@
 slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
-algokit,,!offer:algokit,,,,,,,,,,
-portal-developer,,!offer:portal-developer,,,,,,,,,,
-portal-startup,,!offer:portal-startup,,,,,,,,,,
+algokit,,!offer:algokit,"[""[Website](https://algorand.co/algokit)"",""[Docs](https://dev.algorand.co/algokit/algokit-intro/)""]",,,,,,,,,
+portal-developer,,!offer:portal-developer,"[""[Website](https://www.portalhq.io/)"",""[Docs](https://docs.portalhq.io/)""]",,,,,,,,,
+portal-startup,,!offer:portal-startup,"[""[Buy](https://www.portalhq.io/pricing)"",""[Docs](https://docs.portalhq.io/)""]",,,,,,,,,


### PR DESCRIPTION
## Summary

Adds verified official website, documentation, and purchase links to the three existing Algorand platform listings for AlgoKit and Portal. No rows, offers, plan metadata, or descriptive fields are changed.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope

- Networks affected: Algorand
- Categories affected: platforms
- Improved non-null cells: 3

## Verification

- Opened https://algorand.co/algokit; it returned HTTP 200.
- Opened https://dev.algorand.co/algokit/algokit-intro/; it returned HTTP 200 and documents AlgoKit.
- Opened https://www.portalhq.io/; it returned HTTP 200.
- Opened https://docs.portalhq.io/; it returned HTTP 200 and documents Portal.
- Opened https://www.portalhq.io/pricing; it returned HTTP 200.
- Confirmed the three existing platform rows had empty actionButtons cells.
- Confirmed the values against their canonical offer definitions.
- Searched open PRs for Algorand platform changes; no competing open PR targets listings/specific-networks/algorand/platforms.csv.

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions.**
- [x] **I personally opened and verified every new link I'm adding.**
- [x] **I confirmed the values against their canonical offer row.**
- [x] **This PR is not a blind AI-generated submission.**

The complete official pre-commit workflow passed with exit code 0. The final three-cell diff was manually reviewed.

## Optional

- Rewards address: `0x769f7a238c8874148bcA1aE0736295630C28faF7`
