### PR TITLE
data(astar): add verified MCP action links

### DIFF
--- a/listings/specific-networks/astar/mcpservers.csv
+++ b/listings/specific-networks/astar/mcpservers.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
-alchemy-mcp-server,,!offer:alchemy-mcp-server,,,,,,,,,,,,,,,,,,,,
-blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
-coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,,,,,,,,,,,,,,,,,,,,
-universal-crypto-mcp,,!offer:universal-crypto-mcp,,,,,,,,,,,,,,,,,,,,
-wallet-agent,,!offer:wallet-agent,,,,,,,,,,,,,,,,,,,,
+alchemy-mcp-server,,!offer:alchemy-mcp-server,"[""[Website](https://www.alchemy.com/)"",""[Docs](https://www.alchemy.com/docs/alchemy-mcp-server)""]",,,,,,,,,,,,,,,,,,,
+blockscout-mcp,,!offer:blockscout-mcp,"[""[Website](https://github.com/blockscout/mcp-server)"",""[Docs](https://github.com/blockscout/mcp-server#readme)""]",,,,,,,,,,,,,,,,,,,
+coinbase-agentkit-mcp,,!offer:coinbase-agentkit-mcp,"[""[Website](https://github.com/coinbase/agentkit/tree/main/typescript/framework-extensions/model-context-protocol)"",""[Docs](https://docs.cdp.coinbase.com/agent-kit/core-concepts/model-context-protocol)""]",,,,,,,,,,,,,,,,,,,
+universal-crypto-mcp,,!offer:universal-crypto-mcp,"[""[Website](https://github.com/nirholas/universal-crypto-mcp)"",""[Docs](https://github.com/nirholas/universal-crypto-mcp#readme)""]",,,,,,,,,,,,,,,,,,,
+wallet-agent,,!offer:wallet-agent,"[""[Website](https://github.com/wallet-agent/wallet-agent)"",""[Docs](https://github.com/wallet-agent/wallet-agent#readme)""]",,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Adds verified canonical website and documentation links to five existing Astar MCP listings: Alchemy, Blockscout, Coinbase AgentKit, Universal Crypto MCP, and Wallet Agent. No rows, offers, plan metadata, or descriptive fields are changed.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope

- Networks affected: Astar
- Categories affected: mcpservers
- Improved non-null cells: 5

## Verification

- Confirmed the five existing Astar MCP rows had empty actionButtons cells.
- Confirmed each value against its canonical offer row in references/offers/mcpservers.csv.
- Opened all ten destination URLs and recorded successful HTTP GET responses.
- Searched open PRs for Astar MCP action-button overlap; no competing PR targets these five rows.
- The patch changes only actionButtons values.

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions.**
- [x] **I personally opened and verified every new link I'm adding.**
- [x] **I confirmed the values against their canonical offer row.**
- [x] **This PR is not a blind AI-generated submission.**

The complete official pre-commit workflow passed with exit code 0. The final five-cell diff was manually reviewed.