### PR TITLE
data: add Wormhole bridge listing for Algorand

### DIFF
--- a/listings/specific-networks/algorand/bridges.csv
+++ b/listings/specific-networks/algorand/bridges.csv
@@ -1,3 +1,4 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,supportedChains,tag
 allbridge,,!offer:allbridge-core,"[""[Bridge](https://core.allbridge.io/)"",""[Docs](https://docs-core.allbridge.io/sdk/guides/algorand)""]",mainnet,,,,,,,,,,,,,,,,,,
 messina,,!offer:messina,,mainnet,,,,,,,,,,,,,,,,,,
+wormhole-mainnet,,!offer:wormhole,"[""[Bridge](https://portalbridge.com/)"",""[Wormholescan](https://wormholescan.io/?network=ALGORAND)""]",mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add the missing Wormhole bridge listing for Algorand
- use the existing canonical `wormhole` offer
- add official Bridge and Wormholescan links

## Validation
- validate_csv.py passed
- csv_to_json.py passed
- validate.py passed
- no duplicate slug found
- working tree clean

## Reward
- address: 0x97142f25472f92Eaad42F52AAA8E26DdB10B870F
- network: Ethereum mainnet
- asset: USDC
