### PR TITLE
Add Forest Explorer Faucet for Filecoin mainnet and calibnetAdd forest filecoin faucet

### DIFF
--- a/listings/specific-networks/filecoin/faucets.csv
+++ b/listings/specific-networks/filecoin/faucets.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,price,starred,requiredMainnetBalance,dripLimitAmount,dripLimitPeriod,additionalNotes,tag
 beryx-faucet,Beryx,,"[""[Get tokens](https://beryx.io/faucet)""]",calibnet,FALSE,TRUE,$0,FALSE,,5 tFIL,12h,,
 chainsafe-faucet,ChainSafe,,"[""[Get tokens](https://faucet.calibnet.chainsafe-fil.io/funds.html)""]",calibnet,FALSE,TRUE,$0,FALSE,,100 tFIL,,,
+forest-faucet-calibnet,,!offer:forest-faucet,"[""[Faucet](https://forest-explorer.chainsafe.dev/faucet/calibnet)"",""[Docs](https://docs.forest.chainsafe.io/filecoin_services/)""]",calibnet,,,,,,10 tFIL,24h,"[""5 tFIL per claim; 60-second request cooldown""]",
+forest-faucet-mainnet,,!offer:forest-faucet,"[""[Faucet](https://forest-explorer.chainsafe.dev/faucet/mainnet)"",""[Docs](https://docs.forest.chainsafe.io/filecoin_services/)""]",mainnet,,,,,,0.01 FIL,24h,"[""10-minute request cooldown""]",

--- a/references/offers/faucets.csv
+++ b/references/offers/faucets.csv
@@ -11,6 +11,7 @@ circle-faucet-eurc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](h
 circle-faucet-usdc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](https://developers.circle.com/stablecoins/usdc-contract-addresses)""]",FALSE,TRUE,,$0,FALSE,"[""Dispenses testnet USDC with no real-world value""]",20 USDC,2h,
 core-faucet,Core DAO,Core Testnet Faucet,"[""[Faucet](https://scan.test2.btcs.network/faucet)"",""[Docs](https://docs.coredao.org/docs/Dev-Guide/core-faucet)""]",FALSE,TRUE,,$0,FALSE,"[""Supports Core Testnet2 (1114)""]",1 tCORE2,24h,
 ethglobal-faucet,EthGlobal,,"[""[Faucet](https://ethglobal.com/faucet)""]",TRUE,FALSE,,$69/$99/$129,FALSE,"[""Available only on paid plans""]",0.05 ETH,24h,
+forest-faucet,ChainSafe,Forest Explorer Faucet,"[""[Faucet](https://forest-explorer.chainsafe.dev/faucet)"",""[GitHub](https://github.com/ChainSafe/forest-explorer)""]",FALSE,FALSE,,$0,FALSE,"[""Supports Filecoin mainnet and calibnet""]",,,
 getblock-faucet,GetBlock,,"[""[Faucet](https://getblock.io/faucet/)""]",TRUE,FALSE,0.005 ETH,$0,FALSE,"[""Requires a GetBlock account""]",0.1 ETH,24h,
 getsepolia-faucet,GetSepolia,,"[""[Faucet](https://getsepolia.2bd.net/)""]",FALSE,FALSE,,,FALSE,,0.02 ETH,24h,
 ghost-faucet,GHOST,,"[""[Faucet](https://ghostchain.io/faucet/)""]",FALSE,FALSE,,$0,FALSE,"[""No KYC, geographic restriction, or minimum mainnet balance requirement""]",,,


### PR DESCRIPTION
## Summary

Adds ChainSafe's Forest Explorer Faucet to the canonical faucet offers and Filecoin-specific listings.

The Forest Explorer source confirms faucet support for both Filecoin mainnet and calibnet. This PR adds one canonical faucet offer and two network-specific listings with the verified drip limits and periods.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: filecoin
- Categories affected: faucets

- Additional notes, additional context / screenshots:
  - Adds the canonical `forest-faucet` offer.
  - Adds Filecoin calibnet faucet listing: 10 tFIL / 24h wallet cap.
  - Adds Filecoin mainnet faucet listing: 0.01 FIL / 24h wallet cap.
  - No existing rows were modified or removed.

## Links
- Forest Explorer: https://forest-explorer.chainsafe.dev/faucet
- Source: https://github.com/ChainSafe/forest-explorer
- Related issue(s)/ DB Improvement Proposal: N/A

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [ ] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [ ] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address (for data patching rewards): YOUR_ERC20_WALLET_ADDRESS
- Twitter (X) post link (for +10% of rewards to this PR):
- Rewards address (for data patching rewards): 0x7a29ba42c4eea53d3388c2e44fbe7c8581681d22