### PR TITLE
DBIP 3022 - validate duplicate JSON array elements

### DIFF
--- a/tests/test_validate_csv.py
+++ b/tests/test_validate_csv.py
@@ -1,0 +1,43 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.validate_csv import (
+    CSVValidator,
+    rule_json_array_elements_unique,
+)
+
+
+class JsonArrayUniquenessTests(unittest.TestCase):
+    def _validate(self, value: str):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "sample.csv"
+            with path.open("w", newline="", encoding="utf-8") as handle:
+                writer = csv.DictWriter(handle, fieldnames=["slug", "values"])
+                writer.writeheader()
+                writer.writerow({"slug": "sample", "values": value})
+
+            validator = CSVValidator()
+            validator.add_rule(rule_json_array_elements_unique)
+            return validator.validate_file(path)
+
+    def test_duplicate_string_is_reported_with_location(self):
+        errors = self._validate('["EN", "KO", "KO"]')
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("row 2: column values", errors[0])
+        self.assertIn('duplicate JSON-array element "KO"', errors[0])
+
+    def test_unique_array_is_valid(self):
+        self.assertEqual(self._validate('["EN", "KO"]'), [])
+
+    def test_empty_array_is_valid(self):
+        self.assertEqual(self._validate("[]"), [])
+
+    def test_exact_json_values_are_type_sensitive(self):
+        self.assertEqual(self._validate('[1, true, "1"]'), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_csv.py
+++ b/tools/validate_csv.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Iterator, Callable, List, Dict
 import os
 import csv
+import json
 import re
 
 URL_PATTERN = re.compile(r'https?://', re.IGNORECASE)
@@ -50,6 +51,46 @@ def rule_slug_sorted(path: Path, rows: List[Dict[str, str]]) -> List[str]:
 
     return errors
 
+def _json_value_key(value: object) -> str:
+    """Return a stable, type-preserving key for one JSON value."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+def rule_json_array_elements_unique(path: Path, rows: List[Dict[str, str]]) -> List[str]:
+    """Reject exact duplicate top-level elements in parseable JSON arrays."""
+    errors: List[str] = []
+
+    for row_number, row in enumerate(rows, start=2):  # header = row 1
+        for column, cell in row.items():
+            if column is None or not cell or not cell.strip():
+                continue
+
+            try:
+                value = json.loads(cell)
+            except (TypeError, ValueError):
+                continue
+
+            if not isinstance(value, list):
+                continue
+
+            seen: set[str] = set()
+            reported: set[str] = set()
+            for element in value:
+                key = _json_value_key(element)
+                if key in seen and key not in reported:
+                    errors.append(
+                        f'{path}: row {row_number}: column {column}: '
+                        f'duplicate JSON-array element {key}'
+                    )
+                    reported.add(key)
+                seen.add(key)
+
+    return errors
+
 def looks_like_url(v: str) -> bool:
     return v.startswith("http://") or v.startswith("https://")
 
@@ -89,6 +130,7 @@ def main():
 
     validator = CSVValidator()
     validator.add_rule(rule_slug_sorted)
+    validator.add_rule(rule_json_array_elements_unique)
     #validator.add_rule(rule_links_must_be_quoted)
 
     all_errors: List[str] = []


### PR DESCRIPTION
## Summary

Closes #3022 by adding a generic CSV validation rule for duplicate top-level elements in JSON-array cells.

## Type of change

- [x] Schema/validation tooling change
- [ ] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Documentation/metadata only

## Scope

- `tools/validate_csv.py`
- New unit tests in `tests/test_validate_csv.py`
- Exact JSON values only; no case folding, alias normalization, reordering, or automatic deduplication

## Implementation

The validator reports the CSV path, 1-based data row, column name, and duplicated JSON value. Empty arrays, unique arrays, non-array cells, and malformed/non-array JSON are not reported by this rule.

## Validation

- 4 unit tests pass: duplicate string with location, unique array, empty array, and type-sensitive exact values.
- The validator runs successfully against the cleaned data tree.
- `git diff --check` passes.

## Links

Closes #3022

## Rewards address

Will be provided separately after approval.