### PR TITLE
Add CertiK to Algorand security listings

### DIFF
--- a/listings/specific-networks/algorand/security.csv
+++ b/listings/specific-networks/algorand/security.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,tag,description,planType,planName,price,trial,starred,toolType,deliveryType,executionEnvironment,coverage,compliance
+certik,,!offer:certik,,,,,,,,,,,,,
 hacken-blockchain-protocol-audit,,!offer:hacken-blockchain-protocol-audit,,,,,,,,,,,,,
 hacken-smart-contract-audit,,!offer:hacken-smart-contract-audit,,,,,,,,,,,,,
 halborn-smart-contract-assessment,,!offer:halborn-smart-contract-assessment,"[""[Website](https://www.halborn.com/solutions/smart-contract-assessment)"",""[Discount](https://algorand.co/discounted-service-providers)""]",,,,,,,,,,,,


### PR DESCRIPTION
## What
Adds a CertiK audit listing to the Algorand security catalog (`listings/specific-networks/algorand/security.csv`), referencing the existing `certik` offer.

## Verification
- CertiK operates a dedicated Algorand ecosystem program: https://www.certik.com/ecosystems/algorand and https://skynet.certik.com/boards/algorand
- Published Algorand audits by CertiK (e.g., Glitter Finance - Algorand); CertiK blog documents its Algorand smart-contract audit practice
- `validate_csv.py`, `csv_to_json.py`, `validate.py` all pass