### PR TITLE
Add BitGo wallet listings for Algorand

### DIFF
--- a/listings/specific-networks/algorand/wallets.csv
+++ b/listings/specific-networks/algorand/wallets.csv
@@ -1,5 +1,8 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 atomic-wallet,,!offer:atomic-wallet,"[""[Algorand Wallet](https://atomicwallet.io/algorand-wallet)""]",,,,,,,,,,,,,,,,,,
+bitgo-cold-wallet,,!offer:bitgo-cold-wallet,,,,,,,,,,,,,,,,,,,
+bitgo-custody-wallet,,!offer:bitgo-custody-wallet,,,,,,,,,,,,,,,,,,,
+bitgo-hot-wallet,,!offer:bitgo-hot-wallet,,,,,,,,,,,,,,,,,,,
 clave-wallet,,!offer:clave-wallet,,,,,,,,,,,,,,,,,,,
 coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
 coinomi-wallet,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What
Adds BitGo cold, custody, and hot wallet listings to the Algorand wallets catalog (`listings/specific-networks/algorand/wallets.csv`), referencing the existing `bitgo-cold-wallet`, `bitgo-custody-wallet`, and `bitgo-hot-wallet` offers.

## Verification
- BitGo announced the first multi-signature wallet and custody support for Algorand: https://www.bitgo.com/resources/blog/announcing-first-multi-sig-support-for-algorand/
- BitGo's institutional platform supports Algorand (ALGO); the wallet offers are currently listed only on Ethereum/Stellar (no all-networks row, no duplicate)
- `validate_csv.py`, `csv_to_json.py`, `validate.py` all pass