### PR TITLE
Add Tangem to Algorand wallets

### DIFF
--- a/listings/specific-networks/algorand/wallets.csv
+++ b/listings/specific-networks/algorand/wallets.csv
@@ -17,5 +17,6 @@ onekey,,!offer:onekey,"[""[Algorand Wallet](https://onekey.so/cryptos/algorand/)
 pera,Pera,,"[""[Website](https://perawallet.app/)""]",TRUE,"[""Web"",""iOS"",""Android""]",FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,"[""ALGO"",""Algorand Standard Assets (ASA)""]",TRUE,$0,"[""helpdesk"",""telegram"",""github"",""reddit"",""discord"",""[chat support widget](perawallet.app/contact-us/)""]",,"[""EN"",""ID""]",FALSE,
 ronin-wallet,,!offer:ronin-wallet,,,,,,,,,,,,,,,,,,,
 saakuru-wallet,,!offer:saakuru-wallet,,,,,,,,,,,,,,,,,,,
+tangem,,!offer:tangem,,,,,,,,,,,,,,,,,,,
 trustwallet,,!offer:trustwallet,"[""[Algorand Wallet](https://trustwallet.com/algorand-wallet)""]",,,,,,,,,,,,,,,,,,
 walletverse,,!offer:walletverse,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/algorand/wallets.csv
+++ b/listings/specific-networks/algorand/wallets.csv
@@ -17,6 +17,6 @@ onekey,,!offer:onekey,"[""[Algorand Wallet](https://onekey.so/cryptos/algorand/)
 pera,Pera,,"[""[Website](https://perawallet.app/)""]",TRUE,"[""Web"",""iOS"",""Android""]",FALSE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE,"[""ALGO"",""Algorand Standard Assets (ASA)""]",TRUE,$0,"[""helpdesk"",""telegram"",""github"",""reddit"",""discord"",""[chat support widget](perawallet.app/contact-us/)""]",,"[""EN"",""ID""]",FALSE,
 ronin-wallet,,!offer:ronin-wallet,,,,,,,,,,,,,,,,,,,
 saakuru-wallet,,!offer:saakuru-wallet,,,,,,,,,,,,,,,,,,,
-tangem,,!offer:tangem,,,,,,,,,,,,,,,,,,,
+tangem,,!offer:tangem,"[""[Algorand Wallet](https://tangem.com/en/cryptocurrencies/algorand/)""]",,,,,,,,,,,"[""ALGO"",""Algorand Standard Assets (ASA)""]",,,,,,,
 trustwallet,,!offer:trustwallet,"[""[Algorand Wallet](https://trustwallet.com/algorand-wallet)""]",,,,,,,,,,,,,,,,,,
 walletverse,,!offer:walletverse,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## What
Adds the Tangem hardware wallet to the Algorand wallets catalog (`listings/specific-networks/algorand/wallets.csv`), referencing the existing `tangem` offer.

## Verification
- Tangem's help center lists Algorand among its 93 supported networks: https://tangem.com/en/help-center/coinstokens/
- Dedicated guide "How to Use Algorand (ALGO)": https://tangem.com/en/blog/post/how-to-use-algorand-guide/ ("Tangem fully supports ALGO and Algorand Standard Assets")
- The `tangem` offer is not listed on Algorand (no all-networks row, no duplicate)
- `validate_csv.py`, `csv_to_json.py`, `validate.py` all pass