### PR TITLE
Add OKX Wallet to Filecoin wallets

### DIFF
--- a/listings/specific-networks/filecoin/wallets.csv
+++ b/listings/specific-networks/filecoin/wallets.csv
@@ -18,6 +18,7 @@ ledger,,!offer:ledger,"[""[Website](https://www.ledger.com/coin/wallet/filecoin)
 math-wallet,,!offer:math-wallet,"[""[Website](https://mathwallet.org/filecoin-wallet/en/)""]",,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,"[""[Docs](https://docs.filecoin.io/networks-and-tools/assets/metamask-setup)""]",,,,,,,,,,,,,,,,,,
 nufi-wallet,,!offer:nufi-wallet,,,,,,,,,,,,,,,,,,,
+okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
 ownbit,,!offer:ownbit,,,,,,,,,,,,,,,,,,,
 ronin-wallet,,!offer:ronin-wallet,,,,,,,,,,,,,,,,,,,
 saakuru-wallet,,!offer:saakuru-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/filecoin/wallets.csv
+++ b/listings/specific-networks/filecoin/wallets.csv
@@ -18,7 +18,7 @@ ledger,,!offer:ledger,"[""[Website](https://www.ledger.com/coin/wallet/filecoin)
 math-wallet,,!offer:math-wallet,"[""[Website](https://mathwallet.org/filecoin-wallet/en/)""]",,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,"[""[Docs](https://docs.filecoin.io/networks-and-tools/assets/metamask-setup)""]",,,,,,,,,,,,,,,,,,
 nufi-wallet,,!offer:nufi-wallet,,,,,,,,,,,,,,,,,,,
-okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+okxwallet,,!offer:okxwallet,"[""[Website](https://web3.okx.com/wallet/filecoin)""]",,,,,,,,,,,"[""FIL""]",,,,,,,
 ownbit,,!offer:ownbit,,,,,,,,,,,,,,,,,,,
 ronin-wallet,,!offer:ronin-wallet,,,,,,,,,,,,,,,,,,,
 saakuru-wallet,,!offer:saakuru-wallet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds OKX Wallet (okxwallet) to the Filecoin wallets listings.

- Listing-only row referencing the existing `okxwallet` offer
- OKX Wallet supports Filecoin (verified via OKX official help pages)
- Not present in all-networks listings — no duplicate