### PR TITLE
Add NowPayments to 10 more networks' services

### DIFF
--- a/listings/specific-networks/bitcoin-cash/services.csv
+++ b/listings/specific-networks/bitcoin-cash/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/cardano/services.csv
+++ b/listings/specific-networks/cardano/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/dash/services.csv
+++ b/listings/specific-networks/dash/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/dogecoin/services.csv
+++ b/listings/specific-networks/dogecoin/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/ethereum-classic/services.csv
+++ b/listings/specific-networks/ethereum-classic/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/hedera/services.csv
+++ b/listings/specific-networks/hedera/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/lisk/services.csv
+++ b/listings/specific-networks/lisk/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/litecoin/services.csv
+++ b/listings/specific-networks/litecoin/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/polkadot/services.csv
+++ b/listings/specific-networks/polkadot/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/tezos/services.csv
+++ b/listings/specific-networks/tezos/services.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
+nowpayments,,!offer:nowpayments,,,,,,,,


### PR DESCRIPTION
Adds the NowPayments payment-gateway service to 10 more networks where it verifiably supports the native coin (source: nowpayments.io/supported-coins — ADA, DOT, XTZ, LTC, DOGE, BCH, DASH, ETC, HBAR, LSK).

Listing-only rows referencing the existing `nowpayments` offer. Not present in all-networks — no duplicates.