### PR TITLE
Add NowPayments to 10 more networks' services

### DIFF
--- a/listings/specific-networks/aptos/services.csv
+++ b/listings/specific-networks/aptos/services.csv
@@ -11,3 +11,4 @@ aptos-cli,Aptos,,"[""[Docs](https://aptos.dev/build/cli)""]",CLI,"[""Test"",""Co
 aptos-wallet-adapter,Aptos,,"[""[Docs](https://aptos.dev/build/sdks/wallet-adapter)""]",Tool,"[""AIP-62"",""Modern Wallet Standard""]",$0,,Free,The Aptos Wallet Adapter provides a single interface for Aptos dapps and Aptos wallets to communicate with each other,FALSE
 chainlink-ccip,,!offer:chainlink-ccip,,,,,,,,
 crossmint-free,,!offer:crossmint-free,,,,,,,,
+nowpayments,,!offer:nowpayments,,,,,,,,

--- a/listings/specific-networks/fantom/services.csv
+++ b/listings/specific-networks/fantom/services.csv
@@ -1,3 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 nowpayments,,!offer:nowpayments,,,,,,,,
-remix,,!offer:remix,,,,,,,,

--- a/listings/specific-networks/kaspa/services.csv
+++ b/listings/specific-networks/kaspa/services.csv
@@ -1,3 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 nowpayments,,!offer:nowpayments,,,,,,,,
-remix,,!offer:remix,,,,,,,,

--- a/listings/specific-networks/secret/services.csv
+++ b/listings/specific-networks/secret/services.csv
@@ -1,3 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 nowpayments,,!offer:nowpayments,,,,,,,,
-remix,,!offer:remix,,,,,,,,

--- a/listings/specific-networks/sei/services.csv
+++ b/listings/specific-networks/sei/services.csv
@@ -1,3 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 nowpayments,,!offer:nowpayments,,,,,,,,
-remix,,!offer:remix,,,,,,,,

--- a/listings/specific-networks/ton/services.csv
+++ b/listings/specific-networks/ton/services.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 jetbrains-intellij-ton,,!offer:jetbrains-intellij-ton,,,,,,,,
+nowpayments,,!offer:nowpayments,,,,,,,,
 orbs-ton-access,,!offer:orbs-ton-access,,,,,,,,
 ton-lite-client,,!offer:ton-lite-client,,,,,,,,
 ton-sandbox,,!offer:ton-sandbox,,,,,,,,

--- a/listings/specific-networks/xrpl/services.csv
+++ b/listings/specific-networks/xrpl/services.csv
@@ -1,3 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 nowpayments,,!offer:nowpayments,,,,,,,,
-remix,,!offer:remix,,,,,,,,

--- a/listings/specific-networks/zilliqa/services.csv
+++ b/listings/specific-networks/zilliqa/services.csv
@@ -1,3 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 nowpayments,,!offer:nowpayments,,,,,,,,
-remix,,!offer:remix,,,,,,,,

--- a/listings/specific-networks/zksync/services.csv
+++ b/listings/specific-networks/zksync/services.csv
@@ -1,3 +1,2 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 nowpayments,,!offer:nowpayments,,,,,,,,
-remix,,!offer:remix,,,,,,,,


### PR DESCRIPTION
Adds the NowPayments payment-gateway service to 10 more networks where it verifiably supports the native coin (source: nowpayments.io/supported-coins — KAS, SEI, INJ, APT, ZK, TON, XRP, FTM, SCRT, ZIL).

Listing-only rows referencing the existing `nowpayments` offer. Not present in all-networks — no duplicates.