### PR TITLE
Add Atomic Wallet to 7 networks' wallets

### DIFF
--- a/listings/specific-networks/aptos/wallets.csv
+++ b/listings/specific-networks/aptos/wallets.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 ascoin-wallet,,!offer:ascoin-wallet,,,,,,,,,,,,,,,,,,,
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 backpack,,!offer:backpack,,,,,,,,,,,,,,,,,,,
 cwallet,,!offer:cwallet,,,,,,,,,,,,,,,,,,,
 exodus,,!offer:exodus,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bitcoin-cash/wallets.csv
+++ b/listings/specific-networks/bitcoin-cash/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 bitcoin-com-wallet,,!offer:bitcoin-com-wallet,,,,,,,,,,,,,,,,,,,
 coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
 coinomi-wallet,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bsc/wallets.csv
+++ b/listings/specific-networks/bsc/wallets.csv
@@ -1,6 +1,7 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 alphawallet,,!offer:alphawallet,,,,,,,,,,,,,,,,,,,
 ambire-wallet,,!offer:ambire-wallet,,,,,,,,,,,,,,,,,,,
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 binance-chain-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
 binance-web3-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
 bitget-wallet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/dash/wallets.csv
+++ b/listings/specific-networks/dash/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
 coinomi,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,
 edge-wallet,,!offer:edge-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/ethereum-classic/wallets.csv
+++ b/listings/specific-networks/ethereum-classic/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 ledger,,!offer:ledger,,,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
 safepal,,!offer:safepal,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/fantom/wallets.csv
+++ b/listings/specific-networks/fantom/wallets.csv
@@ -1,5 +1,2 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
-metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
-nufi-wallet,,!offer:nufi-wallet,,,,,,,,,,,,,,,,,,,
-rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds Atomic Wallet to 7 networks where it verifiably supports the native coin (source: atomicwallet.io/assets — APT, BCH, BNB, DASH, ETC, FTM, FLOW).

Listing-only rows referencing the existing `atomic-wallet` offer. Not present in all-networks — no duplicates.