### PR TITLE
Add Atomic Wallet to 6 more networks' wallets

### DIFF
--- a/listings/specific-networks/hedera/wallets.csv
+++ b/listings/specific-networks/hedera/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/near/wallets.csv
+++ b/listings/specific-networks/near/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/polkadot/wallets.csv
+++ b/listings/specific-networks/polkadot/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/sui/wallets.csv
+++ b/listings/specific-networks/sui/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 binance-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
 ledger,,!offer:ledger,,,,,,,,,,,,,,,,,,,
 math-wallet,,!offer:math-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/vechain/wallets.csv
+++ b/listings/specific-networks/vechain/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/zilliqa/wallets.csv
+++ b/listings/specific-networks/zilliqa/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds Atomic Wallet to 6 more networks where it verifiably supports the native coin (source: atomicwallet.io/assets — HBAR, NEAR, DOT, SUI, VET, ZIL).

Listing-only rows referencing the existing `atomic-wallet` offer. Not present in all-networks — no duplicates.