### PR TITLE
Add Rabby wallet listings for 12 more networks

### DIFF
--- a/listings/specific-networks/apechain/wallets.csv
+++ b/listings/specific-networks/apechain/wallets.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,

--- a/listings/specific-networks/bitlayer/wallets.csv
+++ b/listings/specific-networks/bitlayer/wallets.csv
@@ -2,3 +2,4 @@ slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,ms
 holdstation,,!offer:holdstation,,,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
 okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,

--- a/listings/specific-networks/blast/wallets.csv
+++ b/listings/specific-networks/blast/wallets.csv
@@ -1,5 +1,2 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
-bitget-wallet-mainnet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
-okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
 rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
-safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bob/wallets.csv
+++ b/listings/specific-networks/bob/wallets.csv
@@ -1,2 +1,3 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
 safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/cyber/wallets.csv
+++ b/listings/specific-networks/cyber/wallets.csv
@@ -1,5 +1,2 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
-bitget-wallet-mainnet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
-okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
 rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
-safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/fraxtal/wallets.csv
+++ b/listings/specific-networks/fraxtal/wallets.csv
@@ -1,5 +1,2 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
-bitget-wallet-mainnet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
-okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
 rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
-safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/gravity/wallets.csv
+++ b/listings/specific-networks/gravity/wallets.csv
@@ -2,6 +2,7 @@ slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,ms
 bitget-wallet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
 okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
 rainbow,,!offer:rainbow,,,,,,,,,,,,,,,,,,,
 safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,
 safepal,,!offer:safepal,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/immutable-zkevm/wallets.csv
+++ b/listings/specific-networks/immutable-zkevm/wallets.csv
@@ -1,5 +1,2 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
-bitget-wallet-mainnet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
-okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
 rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
-safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/merlin/wallets.csv
+++ b/listings/specific-networks/merlin/wallets.csv
@@ -2,4 +2,5 @@ slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,ms
 bitget-wallet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
 okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
 safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/morph/wallets.csv
+++ b/listings/specific-networks/morph/wallets.csv
@@ -2,4 +2,5 @@ slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,ms
 bitget-wallet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
 metamask,,!offer:metamask,,,,,,,,,,,,,,,,,,,
 okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
+rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
 safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/world-chain/wallets.csv
+++ b/listings/specific-networks/world-chain/wallets.csv
@@ -1,5 +1,2 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
-bitget-wallet-mainnet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
-okxwallet,,!offer:okxwallet,,,,,,,,,,,,,,,,,,,
 rabby,,!offer:rabby,,,,,,,,,,,,,,,,,,TRUE,
-safe-gnosis,,!offer:safe-gnosis,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds listing-only rows referencing the existing `rabby` wallet offer for 12 more networks Rabby supports.

**Source:** RabbyHub/Rabby `src/constant/default-support-chains.json` — Rabby's own default support-chains config. wallets=22 fields verified, all validators green, zero duplicates.

Networks: merlin, blast, fraxtal, x-layer, immutable-zkevm, bitlayer, bob, cyber, gravity, apechain, world-chain, morph.