### PR TITLE
Add AirGap wallet listings for 10 networks

### DIFF
--- a/listings/specific-networks/astar/wallets.csv
+++ b/listings/specific-networks/astar/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 backpack,,!offer:backpack,,,,,,,,,,,,,,,,,,,
 bifrost,,!offer:bifrost,,,,,,,,,,,,,,,,,,,
 clave-wallet,,!offer:clave-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bitcoin/wallets.csv
+++ b/listings/specific-networks/bitcoin/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 ascoin-wallet,,!offer:ascoin-wallet,,,,,,,,,,,,,,,,,,,
 atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 base-wallet,,!offer:base-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bsc/wallets.csv
+++ b/listings/specific-networks/bsc/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 alphawallet,,!offer:alphawallet,,,,,,,,,,,,,,,,,,,
 ambire-wallet,,!offer:ambire-wallet,,,,,,,,,,,,,,,,,,,
 binance-chain-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/cosmos/wallets.csv
+++ b/listings/specific-networks/cosmos/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 crypto-com,,!offer:crypto-com,,,,,,,,,,,,,,,,,,,
 imtoken,,!offer:imtoken,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/ethereum/wallets.csv
+++ b/listings/specific-networks/ethereum/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 alphawallet,,!offer:alphawallet,,,,,,,,,,,,,,,,,,,
 ambire-wallet,,!offer:ambire-wallet,,,,,,,,,,,,,,,,,,,
 ascoin-wallet,,!offer:ascoin-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/moonbeam/wallets.csv
+++ b/listings/specific-networks/moonbeam/wallets.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 1inch,,!offer:1inch,,,,,,,,,,,,,,,,,,,
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 backpack,,!offer:backpack,,,,,,,,,,,,,,,,,,,
 binance-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
 bitget-wallet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/optimism/wallets.csv
+++ b/listings/specific-networks/optimism/wallets.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 1inch,,!offer:1inch,,,,,,,,,,,,,,,,,,,
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 ambire-wallet,,!offer:ambire-wallet,,,,,,,,,,,,,,,,,,,
 atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 base-wallet,,!offer:base-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/polkadot/wallets.csv
+++ b/listings/specific-networks/polkadot/wallets.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/rootstock/wallets.csv
+++ b/listings/specific-networks/rootstock/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 bitget-wallet,,!offer:bitget-wallet,,,,,,,,,,,,,,,,,,,
 coinomi-wallet,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,
 edge-wallet,,!offer:edge-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/stellar/wallets.csv
+++ b/listings/specific-networks/stellar/wallets.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
+airgap,,!offer:airgap,,,,,,,,,,,,,,,,,,,
 airtm,AirTM,,"[""[Website](https://www.airtm.com/)""]",FALSE,"[""Web"",""iOS"",""Android""]",TRUE,TRUE,FALSE,FALSE,FALSE,TRUE,FALSE,FALSE,"[""XLM"",""Stellar-based assets""]",FALSE,Free,"[""Email"",""Helpdesk""]","[""Audit by Quantstamp, 2022""]","[""EN"",""ES"",""PT""]",FALSE,
 atomic-wallet,,!offer:atomic-wallet,,,,,,,,,,,,,,,,,,,
 backpack,,!offer:backpack,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds listing-only rows referencing the existing `airgap` wallet offer for 10 networks AirGap supports.

**Source:** airgap-it/airgap-wallet `package.json` — the `@airgap/*` protocol modules the wallet actually bundles (bitcoin, ethereum, bnb, cosmos, polkadot, stellar, moonbeam, optimism, astar, iso-rootstock). wallets=22 fields verified, all validators green, zero duplicates.

Networks: bitcoin, ethereum, bsc, cosmos, polkadot, stellar, moonbeam, optimism, astar, rootstock.