### PR TITLE
Add Subscan explorer listings for 3 networks

### DIFF
--- a/listings/specific-networks/kusama/explorers.csv
+++ b/listings/specific-networks/kusama/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+subscan-mainnet,,!offer:subscan,"[""[Explore](https://kusama.subscan.io)""]",kusama,,,,,,,,,,,

--- a/listings/specific-networks/peaq/explorers.csv
+++ b/listings/specific-networks/peaq/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+subscan-mainnet,,!offer:subscan,"[""[Explore](https://peaq.subscan.io)""]",peaq,,,,,,,,,,,

--- a/listings/specific-networks/polkadot/explorers.csv
+++ b/listings/specific-networks/polkadot/explorers.csv
@@ -1,0 +1,2 @@
+slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
+subscan-mainnet,,!offer:subscan,"[""[Explore](https://polkadot.subscan.io)""]",polkadot,,,,,,,,,,,


### PR DESCRIPTION
Adds listing-only rows referencing the existing `subscan` explorer offer for 3 networks Subscan covers.

**Source:** support.subscan.io supported-chains table (`polkadot.api.subscan.io live`, `kusama.api.subscan.io live`, `peaq.api.subscan.io live`); explorer URLs verified live (HTTP 200). explorers=16 fields verified, all validators green, zero duplicates.

Networks: polkadot, kusama, peaq.