### PR TITLE
Add CoinGecko API analytics listings for 17 networks

### DIFF
--- a/listings/specific-networks/superposition/analytics.csv
+++ b/listings/specific-networks/superposition/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/superseed/analytics.csv
+++ b/listings/specific-networks/superseed/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/telos/analytics.csv
+++ b/listings/specific-networks/telos/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/tempo/analytics.csv
+++ b/listings/specific-networks/tempo/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/unichain/analytics.csv
+++ b/listings/specific-networks/unichain/analytics.csv
@@ -1,4 +1,7 @@
 slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/unichain)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/unichain)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/unichain)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/vana/analytics.csv
+++ b/listings/specific-networks/vana/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/vechain/analytics.csv
+++ b/listings/specific-networks/vechain/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/viction/analytics.csv
+++ b/listings/specific-networks/viction/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/wanchain/analytics.csv
+++ b/listings/specific-networks/wanchain/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/world-chain/analytics.csv
+++ b/listings/specific-networks/world-chain/analytics.csv
@@ -1,4 +1,7 @@
 slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,
 dune-mainnet-analyst,,!offer:dune-analyst,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,
 dune-mainnet-free,,!offer:dune-free,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,
 dune-mainnet-plus,,!offer:dune-plus,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/x-layer/analytics.csv
+++ b/listings/specific-networks/x-layer/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/xai/analytics.csv
+++ b/listings/specific-networks/xai/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/xrpl-evm/analytics.csv
+++ b/listings/specific-networks/xrpl-evm/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/zetachain/analytics.csv
+++ b/listings/specific-networks/zetachain/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/zilliqa/analytics.csv
+++ b/listings/specific-networks/zilliqa/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/zircuit/analytics.csv
+++ b/listings/specific-networks/zircuit/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/zora/analytics.csv
+++ b/listings/specific-networks/zora/analytics.csv
@@ -1,0 +1,4 @@
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
+coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
+coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,


### PR DESCRIPTION
Adds listing-only rows referencing the existing coingecko-api offers (analyst/basic/lite) for 17 networks CoinGecko covers.

**Source:** CoinGecko public API `asset_platforms`. analytics=14 fields, validators green, zero duplicates.

Networks: superposition, superseed, telos, tempo, unichain, vana, vechain, viction, wanchain, world-chain, x-layer, xai, xrpl-evm, zetachain, zilliqa, zircuit, zora.