### PR TITLE
feat(apis): add Alchemy listing rows to 9 networks

### DIFF
--- a/listings/specific-networks/berachain/apis.csv
+++ b/listings/specific-networks/berachain/apis.csv
@@ -1,3 +1,5 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 berachain-mainnet-public-rpc,,!offer:berachain-public-rpc,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 berachain-testnet-public-rpc,,!offer:berachain-public-rpc,,,,,,,testnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bitcoin-cash/apis.csv
+++ b/listings/specific-networks/bitcoin-cash/apis.csv
@@ -1,4 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-dedicated-full-archive,,!offer:blockdaemon-dedicated-full-archive,"[""[Docs](https://docs.blockdaemon.com/docs/bitcoin-cash-rpc-methods)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-dedicated-recent-state,,!offer:blockdaemon-dedicated-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/bitcoin-cash-rpc-methods)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-free-full-archive,,!offer:blockdaemon-free-full-archive,"[""[Docs](https://docs.blockdaemon.com/docs/bitcoin-cash-rpc-methods)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bitcoin/apis.csv
+++ b/listings/specific-networks/bitcoin/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-full-archive,,!offer:ankr-free-full-archive,"[""[Website](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/btc/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/btc/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-pay-as-you-go-full-archive,,!offer:ankr-pay-as-you-go-full-archive,"[""[Buy](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/btc/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bob/apis.csv
+++ b/listings/specific-networks/bob/apis.csv
@@ -1,4 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-free-recent-state,,!offer:drpc-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-free-recent-state,,!offer:tenderly-free-recent-state,"[""[Docs](https://docs.tenderly.co/node/rpc-reference/bob)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-pay-as-you-go-recent-state,,!offer:tenderly-pay-as-you-go-recent-state,"[""[Buy](https://tenderly.co/pricing)"",""[Docs](https://docs.tenderly.co/node/rpc-reference/bob)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/boba/apis.csv
+++ b/listings/specific-networks/boba/apis.csv
@@ -1,5 +1,7 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,"[""[Docs](https://docs.1rpc.io/using-the-web3-api/networks)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 subquery-mainnet-pay-as-you-go-indexer,,!offer:subquery-pay-as-you-go-indexer,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-dedicated-recent-state,,!offer:tenderly-dedicated-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-free-recent-state,,!offer:tenderly-free-recent-state,"[""[Docs](https://docs.tenderly.co/node/rpc-reference/boba-ethereum-mainnet)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/bsc/apis.csv
+++ b/listings/specific-networks/bsc/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,"[""[Buy](https://www.1rpc.io/#pricing)"",""[Docs](https://docs.1rpc.io/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,"[""[Website](https://www.1rpc.io/)"",""[Docs](https://docs.1rpc.io/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,"[""[Buy](https://www.1rpc.io/#pricing)"",""[Docs](https://docs.1rpc.io/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 allthatnode-mainnet-dedicated-full-archive,,!offer:allthatnode-dedicated-full-archive,"[""[Website](https://www.allthatnode.com/dedicatednode.dsrv)"",""[Docs](https://docs.allthatnode.com/docs/supported-protocols-2)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 allthatnode-mainnet-dedicated-recent-state,,!offer:allthatnode-dedicated-recent-state,"[""[Website](https://www.allthatnode.com/dedicatednode.dsrv)"",""[Docs](https://docs.allthatnode.com/docs/supported-protocols-2)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 allthatnode-mainnet-free-full-archive,,!offer:allthatnode-free-full-archive,"[""[Website](https://www.allthatnode.com/protocol/aptos.dsrv)"",""[Docs](https://docs.allthatnode.com/docs/supported-protocols-1)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/cronos/apis.csv
+++ b/listings/specific-networks/cronos/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-business-full-archive,,!offer:chainstack-business-full-archive,"[""[Buy](https://chainstack.referral-factory.com/uDAlJWDK)"",""[Docs](https://docs.chainstack.com/docs/cronos-methods)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-business-recent-state,,!offer:chainstack-business-recent-state,"[""[Buy](https://chainstack.referral-factory.com/uDAlJWDK)"",""[Docs](https://docs.chainstack.com/docs/cronos-methods)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-developer-recent-state,,!offer:chainstack-developer-recent-state,"[""[Website](https://chainstack.referral-factory.com/uDAlJWDK)"",""[Docs](https://docs.chainstack.com/docs/cronos-methods)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/dogecoin/apis.csv
+++ b/listings/specific-networks/dogecoin/apis.csv
@@ -1,4 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-dedicated-recent-state,,!offer:blockdaemon-dedicated-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/dogecoin)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-free-recent-state,,!offer:blockdaemon-free-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/dogecoin)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-growth-recent-state,,!offer:blockdaemon-growth-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/dogecoin)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/fantom/apis.csv
+++ b/listings/specific-networks/fantom/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-full-archive,,!offer:ankr-free-full-archive,"[""[Website](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/fantom/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/fantom/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-pay-as-you-go-full-archive,,!offer:ankr-pay-as-you-go-full-archive,"[""[Buy](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/fantom/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds Alchemy free + pay-as-you-go API listing rows to networks verified in Alchemy's official docs chain index (alchemy.com/docs/chains).

Networks: berachain, bitcoin, bitcoin-cash, bob, boba, bsc, cronos, dogecoin, fantom

Listing-only rows referencing the existing alchemy-free-recent-state and alchemy-pay-as-you-go-recent-state offers. Validators green (validate_csv, csv_to_json, validate).