### PR TITLE
feat(apis): add Alchemy listing rows to 10 networks

### DIFF
--- a/listings/specific-networks/gnosis/apis.csv
+++ b/listings/specific-networks/gnosis/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-business-full-archive,,!offer:chainstack-business-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-business-recent-state,,!offer:chainstack-business-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-developer-recent-state,,!offer:chainstack-developer-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/injective/apis.csv
+++ b/listings/specific-networks/injective/apis.csv
@@ -3,5 +3,7 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 thirdweb-mainnet-starter-recent-state,,!offer:thirdweb-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/kaia/apis.csv
+++ b/listings/specific-networks/kaia/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 allthatnode-mainnet-free-recent-state,,!offer:allthatnode-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockpi-mainnet-free-recent-state,,!offer:blockpi-free-recent-state,"[""[Website](https://blockpi.io/chain/kaia/)"",""[Docs](https://docs.kaia.io/references/public-en/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/litecoin/apis.csv
+++ b/listings/specific-networks/litecoin/apis.csv
@@ -1,4 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-dedicated-recent-state,,!offer:blockdaemon-dedicated-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/access-litecoin-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-free-recent-state,,!offer:blockdaemon-free-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/access-litecoin-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-growth-recent-state,,!offer:blockdaemon-growth-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/access-litecoin-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/megaeth/apis.csv
+++ b/listings/specific-networks/megaeth/apis.csv
@@ -3,3 +3,5 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/mode/apis.csv
+++ b/listings/specific-networks/mode/apis.csv
@@ -4,3 +4,5 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-testnet-developer-recent-state,,!offer:1rpc-developer-recent-state,,,,,,,testnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/moonbeam/apis.csv
+++ b/listings/specific-networks/moonbeam/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-full-archive,,!offer:ankr-free-full-archive,"[""[Website](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/#moonbeam)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/#moonbeam)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-pay-as-you-go-full-archive,,!offer:ankr-pay-as-you-go-full-archive,"[""[Buy](https://www.ankr.com/rpc/?utm_referral=t26yw96jZJ)"",""[Docs](https://www.ankr.com/docs/rpc-service/service-plans/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/opbnb/apis.csv
+++ b/listings/specific-networks/opbnb/apis.csv
@@ -3,3 +3,5 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/polygon-zkevm/apis.csv
+++ b/listings/specific-networks/polygon-zkevm/apis.csv
@@ -3,3 +3,5 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/sei/apis.csv
+++ b/listings/specific-networks/sei/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+alchemy-mainnet-pay-as-you-go-recent-state,,!offer:alchemy-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-free-recent-state,,!offer:drpc-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds Alchemy free + pay-as-you-go API listing rows verified against Alchemy's official docs chain index (alchemy.com/docs/chains).

Networks: gnosis, injective, kaia, litecoin, megaeth, mode, moonbeam, opbnb, polygon-zkevm, sei

Listing-only rows referencing existing alchemy offers. Validators green.