### PR TITLE
feat(bridges): add ChainPort bridge rows for fuse and iota

### DIFF
--- a/listings/specific-networks/fuse/bridges.csv
+++ b/listings/specific-networks/fuse/bridges.csv
@@ -1,4 +1,5 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+chainport-fuse,,!offer:chainport,,mainnet,,,,,,,,,,,,,,,,,,
 chainspot,,!offer:chainspot,,mainnet,,,,,,,,,,,,,,,,,,
 hyperlane,,!offer:hyperlane,,mainnet,,,,,,,,,,,,,,,,,,
 jumper,,!offer:jumper,,mainnet,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/iota/bridges.csv
+++ b/listings/specific-networks/iota/bridges.csv
@@ -1,3 +1,4 @@
 slug,provider,offer,actionButtons,chain,technology,txSpeedSla,throughputSla,openSource,support,supportedChains,starred,availableApis,monitoringAndAnalytics,additionalFeatures,assetTypes,price,economicalSecurity,economicalSecurityNote,auditsPerformed,decentralizationModel,sdk,tag
+chainport-iota,,!offer:chainport,,mainnet,,,,,,,,,,,,,,,,,,
 interport,,!offer:interport,,mainnet,,,,,,,,,,,,,,,,,,
 stargate,,!offer:stargate,,mainnet,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Adds listing-only ChainPort bridge rows for **fuse** and **iota** — the two networks ChainPort supports that were missing from the catalog listings.

## Source (vendor's own live API, verified 2026-08-19)

`api.chainport.io/api/meta` — ChainPort's public API returns 31 network entries with contract addresses; FUSE and IOTA are in that set (both also listed on the vendor's app.chainport.io).

## Verification

- [x] Slug convention matches existing ChainPort rows (`chainport-<net>`, chain=mainnet)
- [x] validate_csv=0, csv_to_json=0, validate=0 (exit codes checked directly)
- [x] 1 insertion per file, 0 deletions; 23 fields

Reward address (Ethereum mainnet): `0xBc14D9C1E2202E3385e7FE89D5d65D42c90ECaB8`

AI assistance was used for source fetching and CSV formatting; rows mapped from ChainPort's API and manually checked.