### PR TITLE
data(filecoin): add Forest Explorer USDFC faucet

### DIFF
--- a/listings/specific-networks/filecoin/faucets.csv
+++ b/listings/specific-networks/filecoin/faucets.csv
@@ -1,3 +1,4 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,price,starred,requiredMainnetBalance,dripLimitAmount,dripLimitPeriod,additionalNotes,tag
 beryx-faucet,Beryx,,"[""[Get tokens](https://beryx.io/faucet)"",""[Docs](https://docs.filecoin.io/networks/calibration)""]",calibnet,FALSE,TRUE,$0,FALSE,,5 tFIL,12h,,
 chainsafe-faucet,ChainSafe,,"[""[Get tokens](https://faucet.calibnet.chainsafe-fil.io/funds.html)"",""[Docs](https://docs.filecoin.io/build-on-filecoin/developing-contracts/get-test-tokens)""]",calibnet,FALSE,TRUE,$0,FALSE,,100 tFIL,,,
+forest-calibnet-usdfc-faucet,,!offer:forest-usdfc-faucet,,calibnet,,,,,,,,,

--- a/listings/specific-networks/filecoin/faucets.csv
+++ b/listings/specific-networks/filecoin/faucets.csv
@@ -2,3 +2,4 @@ slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,price,starred,r
 beryx-faucet,Beryx,,"[""[Get tokens](https://beryx.io/faucet)"",""[Docs](https://docs.filecoin.io/networks/calibration)""]",calibnet,FALSE,TRUE,$0,FALSE,,5 tFIL,12h,,
 chainsafe-faucet,,!offer:chainsafe-faucet,,calibnet,,,,,,,,,
 ethglobal-filecoin-calibration-faucet,,!offer:ethglobal-faucet,"[""[Faucet](https://ethglobal.com/faucet/filecoin-calibration-314159)""]",calibnet,,,,,,0.05 tFIL,,,
+forest-calibnet-usdfc-faucet,,!offer:forest-usdfc-faucet,,calibnet,,,,,,,,,

--- a/references/offers/faucets.csv
+++ b/references/offers/faucets.csv
@@ -11,6 +11,7 @@ circle-faucet-eurc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](h
 circle-faucet-usdc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](https://developers.circle.com/stablecoins/usdc-contract-addresses)""]",FALSE,TRUE,,$0,FALSE,"[""Dispenses testnet USDC with no real-world value""]",20 USDC,2h,
 core-faucet,Core DAO,Core Testnet Faucet,"[""[Faucet](https://scan.test2.btcs.network/faucet)"",""[Docs](https://docs.coredao.org/docs/Dev-Guide/core-faucet)""]",FALSE,TRUE,,$0,FALSE,"[""Supports Core Testnet2 (1114)""]",1 tCORE2,24h,
 ethglobal-faucet,EthGlobal,,"[""[Faucet](https://ethglobal.com/faucet)""]",TRUE,FALSE,,$69/$99/$129,FALSE,"[""Available only on paid plans""]",0.05 ETH,24h,
+forest-usdfc-faucet,ChainSafe,Forest Explorer USDFC Faucet,"[""[Faucet](https://forest-explorer.chainsafe.dev/faucet/calibnet_usdfc)"",""[Docs](https://docs.filecoin.io/networks-and-tools/networks/calibration)""]",FALSE,FALSE,,$0,FALSE,"[""Dispenses test USDFC for Filecoin Calibration""]",,,"[""Filecoin"",""Calibration"",""USDFC""]"
 getblock-faucet,GetBlock,,"[""[Faucet](https://getblock.io/faucet/)""]",TRUE,FALSE,0.005 ETH,$0,FALSE,"[""Requires a GetBlock account""]",0.1 ETH,24h,
 getsepolia-faucet,GetSepolia,,"[""[Faucet](https://getsepolia.2bd.net/)""]",FALSE,FALSE,,,FALSE,,0.02 ETH,24h,
 ghost-faucet,GHOST,,"[""[Faucet](https://ghostchain.io/faucet/)""]",FALSE,FALSE,,$0,FALSE,"[""No KYC, geographic restriction, or minimum mainnet balance requirement""]",,,

--- a/references/offers/faucets.csv
+++ b/references/offers/faucets.csv
@@ -12,6 +12,7 @@ circle-faucet-eurc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](h
 circle-faucet-usdc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](https://developers.circle.com/stablecoins/usdc-contract-addresses)""]",FALSE,TRUE,,$0,FALSE,"[""Dispenses testnet USDC with no real-world value""]",20 USDC,2h,
 core-faucet,Core DAO,Core Testnet Faucet,"[""[Faucet](https://scan.test2.btcs.network/faucet)"",""[Docs](https://docs.coredao.org/docs/Dev-Guide/core-faucet)""]",FALSE,TRUE,,$0,FALSE,"[""Supports Core Testnet2 (1114)""]",1 tCORE2,24h,
 ethglobal-faucet,EthGlobal,ETHGlobal Testnet Faucet,"[""[Faucet](https://ethglobal.com/faucet)""]",TRUE,FALSE,,$0,FALSE,,,24h,
+forest-usdfc-faucet,ChainSafe,Forest Explorer USDFC Faucet,"[""[Faucet](https://forest-explorer.chainsafe.dev/faucet/calibnet_usdfc)"",""[Docs](https://docs.filecoin.io/networks-and-tools/networks/calibration)""]",FALSE,FALSE,,$0,FALSE,"[""Dispenses test USDFC for Filecoin Calibration""]",,,"[""Filecoin"",""Calibration"",""USDFC""]"
 getblock-faucet,GetBlock,,"[""[Faucet](https://getblock.io/faucet/)""]",TRUE,FALSE,0.005 ETH,$0,FALSE,"[""Requires a GetBlock account""]",0.1 ETH,24h,
 getsepolia-faucet,GetSepolia,,"[""[Faucet](https://getsepolia.2bd.net/)""]",FALSE,FALSE,,,FALSE,,0.02 ETH,24h,
 ghost-faucet,GHOST,,"[""[Faucet](https://ghostchain.io/faucet/)""]",FALSE,FALSE,,$0,FALSE,"[""No KYC, geographic restriction, or minimum mainnet balance requirement""]",,,


### PR DESCRIPTION
## Summary
- add the canonical Forest Explorer USDFC faucet offer from ChainSafe
- list it for Filecoin Calibration through an !offer: reference
- reuse the existing ChainSafe provider and calibnet chain assets
- keep the contribution to two new rows and 13 non-null cells

## Official evidence
- Filecoin's Calibration documentation lists the ChainSafe Calibration USDFC faucet: https://docs.filecoin.io/networks-and-tools/networks/calibration
- Filecoin's official Filecoin Pin tutorial directs builders to the same faucet for test USDFC: https://docs.filecoin.io/builder-cookbook/filecoin-pin/dapp-demo
- ChainSafe's Forest Explorer source identifies the page as the Filecoin Calibnet USDFC Faucet: https://github.com/ChainSafe/forest-explorer/blob/main/src/faucet/views/faucets/calibnet_usdfc.rs

The faucet URL is live behind a Cloudflare browser challenge (HTTP 403 to automated HEAD requests), and both official Filecoin sources above link to it.

## Collision audit
- searched current main and open PRs for both new slugs and the exact faucet URL; no match
- related PRs #2588, #2915 and #3011 cover Forest/ChainSafe tFIL faucets, not USDFC
- #3126 covers a different USDFC faucet from Plumbline at a different URL
- repeated the search immediately before publication

## Validation
- official json-tools validate_csv.py: All checks passed
- official csv_to_json.py generation: passed
- official validate.py schema validation for all generated network JSON: passed
- offer/listing widths: 13/14 columns
- git diff --check: passed

## Rewards address
0x06f44f4839fd5df4f4670036d028b29dec939363