### PR TITLE
[DBIP] explorers: pricing → price in schema and metadata

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -351,17 +351,6 @@
     "cellType": null,
     "group": "capabilities"
   },
-  "pricing": {
-    "key": "pricing",
-    "label": "Pricing",
-    "icon": "lucide:BadgeDollarSign",
-    "description": "Pricing model/notes.",
-    "filter": "searchableMultiSelect",
-    "sorting": "string",
-    "pinning": null,
-    "cellType": null,
-    "group": "pricing"
-  },
   "dataTypes": {
     "key": "dataTypes",
     "label": "Data Types",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -160,7 +160,7 @@
         },
         "smartContractsVerifications": { "type": "boolean" },
         "fullHistory": { "type": "boolean" },
-        "pricing": { "type": ["string", "null"] },
+        "price": { "type": ["string", "null"] },
         "actionButtons": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -180,7 +180,7 @@
         "searchCapabilities",
         "smartContractsVerifications",
         "fullHistory",
-        "pricing",
+        "price",
         "actionButtons",
         "tag"
       ]


### PR DESCRIPTION
## Summary
Paired schema/metadata commit for approved DBIP #2481 (main-branch CSV rename in #3259).

- `tools/schema.json`: `$defs.explorers` properties+required `pricing` → `price`
- `meta/columns.json`: drop redundant explorers-specific `pricing` entry (common `price` covers it)

## Test plan
- [x] Schema validates renamed column
- [x] columns.json consistent with common price metadata
- [x] Paired with main CSV rename PR #3259

Fixes #2481

Made with [Cursor](https://cursor.com)