### PR TITLE
[DBIP] Rename economic security columns in schema (fixes #2681)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -384,9 +384,9 @@
     "cellType": null,
     "group": "security"
   },
-  "economicalSecurity": {
-    "key": "economicalSecurity",
-    "label": "Economical Security",
+  "economicSecurity": {
+    "key": "economicSecurity",
+    "label": "Economic Security",
     "icon": "lucide:ShieldHalf",
     "description": "Provides economic security guarantees.",
     "filter": "select",
@@ -395,9 +395,9 @@
     "cellType": null,
     "group": "security"
   },
-  "economicalSecurityNote": {
-    "key": "economicalSecurityNote",
-    "label": "Economical Security Note",
+  "economicSecurityNote": {
+    "key": "economicSecurityNote",
+    "label": "Economic Security Note",
     "icon": "lucide:ShieldEllipsis",
     "description": "Notes about economic security.",
     "filter": "select",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -213,8 +213,8 @@
           "items": { "type": "string" }
         },
         "decentralizationModel": { "type": ["string", "null"] },
-        "economicalSecurity": { "type": "boolean" },
-        "economicalSecurityNote": { "type": ["string", "null"] },
+        "economicSecurity": { "type": "boolean" },
+        "economicSecurityNote": { "type": ["string", "null"] },
         "sdk": { "type": ["array", "null"], "items": { "type": "string" } },
         "auditsPerformed": {
           "type": ["array", "null"],
@@ -237,8 +237,8 @@
         "additionalFeatures",
         "dataTypes",
         "decentralizationModel",
-        "economicalSecurity",
-        "economicalSecurityNote",
+        "economicSecurity",
+        "economicSecurityNote",
         "sdk",
         "auditsPerformed",
         "actionButtons",
@@ -281,8 +281,8 @@
         "txSpeedSla": { "type": ["string", "null"] },
         "throughputSla": { "type": ["string", "null"] },
         "price": { "type": ["string", "null"] },
-        "economicalSecurity": { "type": "boolean" },
-        "economicalSecurityNote": { "type": ["string", "null"] },
+        "economicSecurity": { "type": "boolean" },
+        "economicSecurityNote": { "type": ["string", "null"] },
         "auditsPerformed": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -311,8 +311,8 @@
         "txSpeedSla",
         "throughputSla",
         "price",
-        "economicalSecurity",
-        "economicalSecurityNote",
+        "economicSecurity",
+        "economicSecurityNote",
         "auditsPerformed",
         "decentralizationModel",
         "sdk",


### PR DESCRIPTION
## Summary
- Rename `economicalSecurity` → `economicSecurity` and `economicalSecurityNote` → `economicSecurityNote` in `$defs.bridges` and `$defs.oracles` (`properties` + `required`)
- Update `meta/columns.json` keys, labels, and descriptions to use correct "economic security" spelling

This is the **json-tools** half of approved DBIP #2681. The paired main-branch data PR renames headers across 219 `bridges.csv` / `oracles.csv` files (header-only, zero data drift).

Fixes #2681