### PR TITLE
[DBIP] explorers: smartContractsVerifications → smartContractVerification (schema)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -329,9 +329,9 @@
     "cellType": "arrayPopover",
     "group": "capabilities"
   },
-  "smartContractsVerifications": {
-    "key": "smartContractsVerifications",
-    "label": "Smart Contracts Verifications",
+  "smartContractVerification": {
+    "key": "smartContractVerification",
+    "label": "Smart Contract Verification",
     "icon": "lucide:ShieldCheck",
     "description": "Supports contract verification.",
     "filter": "select",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -158,7 +158,7 @@
           "type": ["array", "null"],
           "items": { "type": "string" }
         },
-        "smartContractsVerifications": { "type": "boolean" },
+        "smartContractVerification": { "type": "boolean" },
         "fullHistory": { "type": "boolean" },
         "pricing": { "type": ["string", "null"] },
         "actionButtons": {
@@ -178,7 +178,7 @@
         "availableApis",
         "sdk",
         "searchCapabilities",
-        "smartContractsVerifications",
+        "smartContractVerification",
         "fullHistory",
         "pricing",
         "actionButtons",


### PR DESCRIPTION
## Summary
Paired **json-tools** schema commit for DBIP #3256 (main CSV rename is in #3258).

- `tools/schema.json`: rename `smartContractsVerifications` → `smartContractVerification` in `$defs.explorers` properties + required
- `meta/columns.json`: update key and singular label

Fixes #3256

## Test plan
- [x] Minimal 5-line surgical diff (no JSON reformat noise)
- [x] `json.load` validates schema.json
- [x] Pairs with main data PR #3258