### PR TITLE
feat(schema): add trial column to storages (DBIP #2561)

### DIFF
--- a/tools/schema.json
+++ b/tools/schema.json
@@ -376,6 +376,7 @@
         "price": { "type": ["string", "null"] },
         "tag": { "type": ["array", "null"], "items": { "type": "string" } },
         "description": { "type": ["string", "null"] },
+        "trial": { "type": "boolean" },
         "starred": { "type": "boolean" },
         "actionButtons": {
           "type": ["array", "null"],
@@ -401,6 +402,7 @@
         "price",
         "tag",
         "description",
+        "trial",
         "starred",
         "actionButtons",
         "planType"


### PR DESCRIPTION
## Summary

Adds `trial` boolean to `$defs.storages` in `tools/schema.json`, aligning storages with mcpservers/platforms/sdks/apis/security categories that already expose a machine-readable trial field.

## Type of change

- [x] Schema change (linked DBIP below)

## Scope

- Categories affected: storages

## Links

- Closes #2561
- Companion data PR: (main branch CSV backfill — submitted separately)

## Validation

- [x] `validate_csv.py` passes on patched data
- [x] `csv_to_json.py` generates storages records with `trial` boolean
- [x] Acceptance test suite: `artifacts_store/test_JOB-BNT-2561_dbip_storages_trial_column.py`

## Rewards address

Not included in this PR (schema-only).