### PR TITLE
data(filecoin): add verified platform action links

### DIFF
--- a/listings/specific-networks/filecoin/platforms.csv
+++ b/listings/specific-networks/filecoin/platforms.csv
@@ -1,7 +1,7 @@
 slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
-4everland-free,,!offer:4everland-free,,,,,,,,,,
-4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,,,,,,,,,,
-apeworx,,!offer:apeworx,,,,,,,,,,
-portal-developer,,!offer:portal-developer,,,,,,,,,,
-portal-startup,,!offer:portal-startup,,,,,,,,,,
-spheron-network,,!offer:spheron-network,,,,,,,,,,
+4everland-free,,!offer:4everland-free,"[""[Website](https://www.4everland.org/)""]",,,,,,,,,
+4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,"[""[Docs](https://docs.4everland.org/get-started/billing-and-pricing/pricing-model)""]",,,,,,,,,
+apeworx,,!offer:apeworx,"[""[Docs](https://docs.apeworx.io/)""]",,,,,,,,,
+portal-developer,,!offer:portal-developer,"[""[Website](https://www.portalhq.io/)"",""[Docs](https://docs.portalhq.io/)""]",,,,,,,,,
+portal-startup,,!offer:portal-startup,"[""[Buy](https://www.portalhq.io/pricing)"",""[Docs](https://docs.portalhq.io/)""]",,,,,,,,,
+spheron-network,,!offer:spheron-network,"[""[Website](https://www.spheron.network)""]",,,,,,,,,


### PR DESCRIPTION
## Summary

- Add canonical action buttons to the six existing Filecoin platform rows.
- Reuse the official URLs already maintained in references/offers/platforms.csv.
- Keep offer references and all service metadata unchanged.

## Validation

- py validate_csv.py
- py csv_to_json.py
- py validate.py
- Confirmed the linked official 4EVERLAND, ApeWorX, Portal, and Spheron pages are reachable.

## Scope

One CSV file and six previously empty actionButtons cells. Maintainer: please apply the check-links label for the isolated URL check.

## Optional

- Rewards address: `0x769f7a238c8874148bcA1aE0736295630C28faF7`
