### PR TITLE
data(gnosis): add canonical MCP action links

### DIFF
--- a/listings/specific-networks/gnosis/mcpservers.csv
+++ b/listings/specific-networks/gnosis/mcpservers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,serverType,hostingType,transportType,mcpEndpoint,authType,credentialKey,selfHostedCommand,selfHostedArgs,selfHostedRequiredEnvVars,x402,onChainWrite,agentSkills,tag,description,planType,planName,price,trial,starred
-blockscout-mcp,,!offer:blockscout-mcp,,,,,,,,,,,,,,,,,,,,
-etherscan-hosted-mcp,,!offer:etherscan-hosted-mcp,,,,,,,,,,,,,,,,,,,,
+blockscout-mcp,,!offer:blockscout-mcp,"[""[Website](https://github.com/blockscout/mcp-server)"",""[Docs](https://github.com/blockscout/mcp-server#readme)""]",,,,,,,,,,,,,,,,,,,
+etherscan-hosted-mcp,,!offer:etherscan-hosted-mcp,"[""[Docs](https://docs.etherscan.io/mcp-docs/introduction)""]",,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Fill the two existing Gnosis MCP server `actionButtons` cells for Blockscout and Etherscan using the exact links already maintained by their canonical `!offer:` rows. No providers, offers, endpoints, pricing, or descriptive metadata are changed.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change

## Scope

- Networks affected: Gnosis
- Categories affected: mcpservers
- Additional notes: two existing listing rows only; no other Gnosis categories are touched.

## Links

- Related issue(s)/DBIP: N/A

## Validation checklist

- [x] I followed the Style Guide and Column Definitions.
- [x] I personally opened and verified every link added.
- [x] No new entries were added; the existing canonical offer references remain unchanged.
- [x] This PR is not a blind AI-generated submission.

Validation performed:
- Official CSV validator: passed
- Isolated CSV-to-JSON generation and schema validation: passed
- CSV width: 23 columns on every row
- Canonical action-link equality: 2/2
- Unique URLs: all returned HTTP 200

## Optional

- Rewards address (for data patching rewards): `0x769f7a238c8874148bcA1aE0736295630C28faF7`
- Twitter (X) post link: N/A
