### PR TITLE
data(katana): add canonical service action links

### DIFF
--- a/listings/specific-networks/katana/services.csv
+++ b/listings/specific-networks/katana/services.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
-chainlink-ccip,,!offer:chainlink-ccip,,service,,,,,,
-zero-dev-developer,,!offer:zero-dev-developer,,service,,,,,,
+chainlink-ccip,,!offer:chainlink-ccip,"[""[Docs](https://docs.chain.link/ccip)""]",service,,,,,,
+zero-dev-developer,,!offer:zero-dev-developer,"[""[Docs](https://docs.zerodev.app/)""]",service,,,,,,


### PR DESCRIPTION
## Summary

Fill the two existing Katana service `actionButtons` cells for Chainlink CCIP and ZeroDev using the exact links already maintained by their canonical `!offer:` rows. No providers, offers, pricing, tool types, or descriptive metadata are changed.

## Type of change

- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change

## Scope

- Networks affected: Katana
- Categories affected: services
- Additional notes: two existing listing rows only; no other Katana categories are touched.

## Links

- Related issue(s)/DBIP: N/A

## Validation checklist

- [x] I followed the Style Guide and Column Definitions.
- [x] I personally opened and verified every link added.
- [x] No new entries were added; the existing canonical offer references remain unchanged.
- [x] This PR is not a blind AI-generated submission.

Validation performed:
- Official CSV validator: passed
- Isolated CSV-to-JSON generation and schema validation: passed
- CSV width: 11 columns on every row
- Canonical action-link equality: 2/2
- Unique URLs: all returned HTTP 200

## Optional

- Rewards address (for data patching rewards): `0x769f7a238c8874148bcA1aE0736295630C28faF7`
- Twitter (X) post link: N/A
