### PR TITLE
data(filecoin): remove discontinued Lava public RPC listing (endpoint 410 Gone)

### DIFF
--- a/listings/specific-networks/filecoin/apis.csv
+++ b/listings/specific-networks/filecoin/apis.csv
@@ -49,7 +49,6 @@ goldsky-mainnet-free-indexer,,!offer:goldsky-free-indexer,"[""[Website](https://
 goldsky-mainnet-pay-as-you-go-indexer,,!offer:goldsky-pay-as-you-go-indexer,"[""[Buy](https://goldsky.com/pricing)"",""[Docs](https://docs.goldsky.com/chains/filecoin)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 indexing-co-mainnet-free-indexer,,!offer:indexing-co-free-indexer,"[""[Docs](https://docs.indexing.co/networks/filecoin)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 indexing-co-mainnet-pay-as-you-go-indexer,,!offer:indexing-co-pay-as-you-go-indexer,"[""[Docs](https://docs.indexing.co/networks/filecoin)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
-lavanetwork-public-mainnet,,!offer:lavanetwork-public-recent-state,"[""[Send requests](https://filecoin.lava.build/)"",""[Docs](https://docs.lavanet.xyz/public-rpc-endpoints/#filecoin)""]",,,,,,mainnet,,,,,"[""All read methods + MPoolPush""]",,,,,,,,,,,,,,
 nodit-mainnet-dedicated-full-archive,,!offer:nodit-dedicated-full-archive,"[""[Docs](https://developer.nodit.io/en/guides/dedicated-node/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 nodit-mainnet-dedicated-recent-state,,!offer:nodit-dedicated-recent-state,"[""[Docs](https://developer.nodit.io/en/guides/dedicated-node/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 nownodes-mainnet-business-recent-state,,!offer:nownodes-business-recent-state,"[""[Buy](https://nownodes.io/pricing)"",""[Docs](https://nownodes.gitbook.io/fil-filecoin/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Removes the `lavanetwork-public-mainnet` row from `listings/specific-networks/filecoin/apis.csv` — the Lava public Filecoin RPC endpoint has been discontinued by the provider, so the listing now fails the quality-gateway "providers that no longer exist / broken or dead links" criteria.

Evidence (verified 2026-08-30):

1. `https://filecoin.lava.build/` returns **HTTP 410 Gone**, body:
   `{"error":"This endpoint has been discontinued.","message":"For an up to date list of available endpoints, visit https://gateway.lavanet.xyz"}`
2. The docs link used by the row (`https://docs.lavanet.xyz/public-rpc-endpoints/#filecoin`) no longer has a Filecoin section — the rendered page only has `Lava` and `Starknet` headings (source: https://github.com/lavanet/docs/blob/master/docs/lava-public-rpc/public-rpc-endpoints.md), so the `#filecoin` anchor is dead too.
3. The suggested replacement `gateway.lavanet.xyz` redirects to a login page, i.e. there is no signup-free public Filecoin endpoint from Lava anymore — the row's value (free public RPC, `!offer:lavanetwork-public-recent-state`) no longer exists for Filecoin.
4. The offer itself stays valid for other networks (Starknet public endpoint still live — I probed `starknet_blockNumber` on `https://rpc.starknet.lava.build` and got a valid JSON-RPC result), so this PR only removes the Filecoin **listing** and leaves `references/offers/apis.csv` and `references/providers/providers.csv` untouched.

No other Filecoin row references this offer (`grep` over `listings/` confirms the removed row was the only `!offer:lavanetwork-public-recent-state` usage in the filecoin folder), so the file stays consistent after the deletion.

## Type of change
- [ ] Add data rows
- [ ] Update data rows
- [x] Remove data rows
- [ ] Schema change <!-- (requires linked DBIP below) -->
- [ ] Documentation/metadata only


## Scope
- Networks affected: filecoin
- Categories affected: apis

- Additional notes, additional context / screenshots:

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): none

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.** (this PR adds no new links; the removed link's death is evidenced above)
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission** — disclosure: this PR was prepared by an autonomous agent, but the endpoint death was verified by live HTTP probes (410 + the provider's own discontinuation message), the docs-anchor check, and a live JSON-RPC call to the still-working Starknet endpoint to scope the removal correctly. No blind generation; every claim above is reproducible with curl.

## Optional
- Rewards address (for data patching rewards): `0x5439BC46AC9cc70dfFC500611c6D845d7eE9eE5E` (USDC/USDT on Ethereum mainnet)
- Twitter (X) post link (for +10% of rewards to this PR):
