### PR TITLE
data(somnia): add canonical service action links

### DIFF
--- a/listings/specific-networks/somnia/services.csv
+++ b/listings/specific-networks/somnia/services.csv
@@ -1,8 +1,8 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
-agent-kit,,!offer:agent-kit,,,,,,,,
-chain-ide,,!offer:chain-ide,,,,,,,,
+agent-kit,,!offer:agent-kit,"[""[Website](https://docs.cdp.coinbase.com/agent-kit/welcome)""]",,,,,,,
+chain-ide,,!offer:chain-ide,"[""[Website](https://chainide.com/)""]",,,,,,,
 pimlico-account-abstraction,,!offer:pimlico-account-abstraction,"[""[Docs](https://docs.somnia.network/developer/deployment-and-production/ecosystem/ecosystem-tools)""]",,,,,,,
-reown-free,,!offer:reown-free,,,,,,,,
-reown-pro,,!offer:reown-pro,,,,,,,,
-scaffold-eth,,!offer:scaffold-eth,,,,,,,,
+reown-free,,!offer:reown-free,"[""[Website](https://reown.com/)"",""[Docs](https://docs.reown.com/)""]",,,,,,,
+reown-pro,,!offer:reown-pro,"[""[Website](https://reown.com/)"",""[Docs](https://docs.reown.com/)""]",,,,,,,
+scaffold-eth,,!offer:scaffold-eth,"[""[Website](https://github.com/scaffold-eth/scaffold-eth-2)""]",,,,,,,
 somnia-agents-skills,,!offer:somnia-agents-skills,,,,,,,,


### PR DESCRIPTION
## Summary
- fills only 5 missing `actionButtons` cells in `listings/specific-networks/somnia/services.csv`
- reuses the exact canonical values from `references/offers/services.csv`
- no overlap with currently open PRs for this file

## Validation
- `git diff --check`
- CSV shape: 6 rows, 11 columns each
- canonical equality for all 5 changed rows
- 5 unique canonical URLs returned HTTP 200
- `validate_csv.py` passed
- `csv_to_json.py` completed; the repository-level schema validator is currently incompatible with this base's generated `schemaVersion: 1.0.0` documents, while its copied schema requires `2.0.0` (baseline-wide, unrelated to this change)

## Optional

- Rewards address: `0x769f7a238c8874148bcA1aE0736295630C28faF7`
