### PR TITLE
data(stellar): add canonical service action links

### DIFF
--- a/listings/specific-networks/stellar/services.csv
+++ b/listings/specific-networks/stellar/services.csv
@@ -1,9 +1,9 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
-bitbond-token-tool-pay-as-you-go,,!offer:bitbond-token-tool-pay-as-you-go,,,,,,,,
-chain-ide,,!offer:chain-ide,,,,,,,,
-chainlink-ccip,,!offer:chainlink-ccip,,,,,,,,
+bitbond-token-tool-pay-as-you-go,,!offer:bitbond-token-tool-pay-as-you-go,"[""[Buy](https://tokentool.bitbond.com/pricing)"",""[Docs](https://docs.bitbond.com/asset-tokenization-suite)""]",,,,,,,
+chain-ide,,!offer:chain-ide,"[""[Website](https://chainide.com/)""]",,,,,,,
+chainlink-ccip,,!offer:chainlink-ccip,"[""[Docs](https://docs.chain.link/ccip)""]",,,,,,,
 crossmint-free,,!offer:crossmint-free,,,,,,,,
-reown-free,,!offer:reown-free,,,,,,,,
-reown-pro,,!offer:reown-pro,,,,,,,,
+reown-free,,!offer:reown-free,"[""[Website](https://reown.com/)"",""[Docs](https://docs.reown.com/)""]",,,,,,,
+reown-pro,,!offer:reown-pro,"[""[Website](https://reown.com/)"",""[Docs](https://docs.reown.com/)""]",,,,,,,
 soroban-cli,Soroban CLI,,"[""[Docs](https://github.com/stellar/stellar-cli)""]",CLI,"[""CLI"",""Soroban""]",$0 ,,Free,"CLI for developing, testing, and deploying Soroban smart contracts",FALSE
 stellar-laboratory,Stellar Laboratory,,"[""[Docs](https://lab.stellar.org/)""]",Testing Environment,"[""Testing"",""Horizon"",""Soroban""]",$0 ,,Free,"Web tool for testing transactions, accounts, and Soroban contracts",FALSE


### PR DESCRIPTION
## Summary
- fills 5 missing `actionButtons` cells in `listings/specific-networks/stellar/services.csv`
- reuses exact canonical values from `references/offers/services.csv`
- intentionally leaves `crossmint-free` unchanged because its canonical site is currently unavailable to strict HTTPS validation
- no overlap with currently open PRs for this file

## Validation
- `git diff --check`
- CSV shape: 8 rows, 11 columns each
- canonical equality for all 5 changed rows
- 6 unique canonical URLs returned HTTP 200
