### PR TITLE
data(filecoin): add verified platform action links

### DIFF
--- a/listings/specific-networks/filecoin/platforms.csv
+++ b/listings/specific-networks/filecoin/platforms.csv
@@ -1,7 +1,7 @@
 slug,provider,offer,actionButtons,toolType,description,tag,planType,planName,price,trial,availableApis,executionEnvironment
-4everland-free,,!offer:4everland-free,,,,,,,,,,
-4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,,,,,,,,,,
-apeworx,,!offer:apeworx,,,,,,,,,,
+4everland-free,,!offer:4everland-free,"[""[Website](https://www.4everland.org/)""]",,,,,,,,,
+4everland-pay-as-you-go,,!offer:4everland-pay-as-you-go,"[""[Docs](https://docs.4everland.org/get-started/billing-and-pricing/pricing-model)""]",,,,,,,,,
+apeworx,,!offer:apeworx,"[""[Docs](https://docs.apeworx.io/)""]",,,,,,,,,
 portal-developer,,!offer:portal-developer,,,,,,,,,,
 portal-startup,,!offer:portal-startup,,,,,,,,,,
-spheron-network,,!offer:spheron-network,,,,,,,,,,
+spheron-network,,!offer:spheron-network,"[""[Website](https://www.spheron.network)""]",,,,,,,,,


### PR DESCRIPTION
## Summary
- fills 4 missing `actionButtons` cells in `listings/specific-networks/filecoin/platforms.csv`
- reuses exact canonical values from `references/offers/platforms.csv`
- intentionally leaves `portal-developer` and `portal-startup` unchanged because their shared canonical documentation URL currently fails strict HTTPS validation
- no overlap with currently open PRs for this file

## Validation
- `git diff --check`
- CSV shape: 6 rows, 13 columns each
- canonical equality for all 4 changed rows
- 4 unique canonical URLs returned HTTP 200

## Optional

- Rewards address: `0x769f7a238c8874148bcA1aE0736295630C28faF7`
