### PR TITLE
Add missing Filecoin storage plan listings

### DIFF
--- a/listings/specific-networks/filecoin/storages.csv
+++ b/listings/specific-networks/filecoin/storages.csv
@@ -1,7 +1,13 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planType,planName,description,starred
+cidgravity-advanced,,!offer:cidgravity-advanced,,,,,,,,
+cidgravity-pro,,!offer:cidgravity-pro,,,,,,,,
+cidgravity-starter,,!offer:cidgravity-starter,,,,,,,,
+fil-one-object-storage,,!offer:fil-one-object-storage,,,,,,,,
+filebase-enterprise,,!offer:filebase-enterprise,,,,,,,,
 filebase-free,,!offer:filebase-free,,,,,,,,
 filebase-pay-as-you-go,,!offer:filebase-pay-as-you-go,,,,,,,,
 filecoin-onchain-cloud-warm-storage,,!offer:filecoin-onchain-cloud-warm-storage,,,,,,,,
+lighthouse-enterprise,,!offer:lighthouse-enterprise,,,,,,,,
 lighthouse-free,,!offer:lighthouse-free,,,,,,,,
 lighthouse-lite,,!offer:lighthouse-lite,,,,,,,,
 lighthouse-premium,,!offer:lighthouse-premium,,,,,,,,


### PR DESCRIPTION
## Summary

Add six missing Filecoin storage plan listings whose canonical offers already exist: CIDgravity Starter, Pro, and Advanced; Fil One Object Storage; Filebase Enterprise; and Lighthouse Enterprise.

## Type of change
- [x] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: filecoin
- Categories affected: storages
- Additional notes: AI-assisted, source-verified data patch. Each listing inherits its canonical offer through `!offer:` and adds no duplicate provider metadata.

## Sources
- CIDgravity pricing: https://www.cidgravity.com/pricing
- CIDgravity docs: https://docs.cidgravity.com/
- Fil One docs: https://docs.fil.one/
- Filebase pricing: https://filebase.com/pricing/
- Lighthouse pricing: https://www.lighthouse.storage/pricing
- Lighthouse docs: https://docs.lighthouse.storage/

## Validation checklist
- [x] **I followed the Style Guide and Column Definitions. I am aware of the `!provider` and `!offer` inheritance syntax.**
- [x] **Every source link above was opened and verified as valid.**
- [x] **Current Filecoin support and the adjusted values were verified against first-party sources.**
- [x] **This PR is not a blind AI-generated submission.**

Validation performed:
- CSV schema, slug ordering, uniqueness, and canonical `!offer` resolution pass.
- `validate_csv.py` passes.
- The repository-wide `csv_to_json.py` currently exits 1 without diagnostics on a pristine checkout of upstream `main` as well, so that failure is not introduced by this patch.

## Optional
- Rewards address (Ethereum mainnet): `0x150E9637489fCc5495F0C1c92232bbfe959E5411`
- Twitter (X) post link: none