### PR TITLE
data(base/gnosis/mode/soneium): repoint 4 dead /api-docs Blockscout links to the live docs.blockscout.com API home

### DIFF
--- a/listings/specific-networks/base/explorers.csv
+++ b/listings/specific-networks/base/explorers.csv
@@ -2,7 +2,7 @@ slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additi
 arkham-mainnet,,!offer:arkham,,mainnet,,,,,,,,,,,
 blockscan-mainnet,,!offer:blockscan,,mainnet,,,,,,,,,,,
 blockscan-testnet,,!offer:blockscan,,testnet,,,,,,,,,,,
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://base.blockscout.com/)"",""[Docs](https://base.blockscout.com/api-docs)""]",mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://base.blockscout.com/)"",""[Docs](https://docs.blockscout.com/devs/apis)""]",mainnet,,,,,,,,,,,
 blockscout-sepolia,,!offer:blockscout,"[""[Explore](https://base-sepolia.blockscout.com/)""]",sepolia,,,,,,,,,,,
 chainlens-growth,,!offer:chainlens-growth,,mainnet,,,,,,,,,,,
 chainlens-pro,,!offer:chainlens-pro,,mainnet,,,,,,,,,,,

--- a/listings/specific-networks/gnosis/explorers.csv
+++ b/listings/specific-networks/gnosis/explorers.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://gnosisscan.io/)"",""[Docs](https://docs.blockscout.com/)""]",mainnet,,,,,,,,,,,
-blockscout-testnet,,!offer:blockscout,"[""[Explore](https://gnosis-chiado.blockscout.com/)"",""[Docs](https://gnosis-chiado.blockscout.com/api-docs)""]",testnet,,,,,,,,,,,
+blockscout-testnet,,!offer:blockscout,"[""[Explore](https://gnosis-chiado.blockscout.com/)"",""[Docs](https://docs.blockscout.com/devs/apis)""]",testnet,,,,,,,,,,,
 oklink-mainnet,,!offer:oklink,"[""[Explore](https://www.oklink.com/gnosis)"",""[Docs](https://www.oklink.com/docs/en/#developer-tools)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/gnosis)"",""[Docs](https://docs.tenderly.co/platform/supported-networks)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-testnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/gnosis-chiado)"",""[Docs](https://docs.tenderly.co/platform/supported-networks)""]",testnet,,,,,,,,,,,

--- a/listings/specific-networks/mode/explorers.csv
+++ b/listings/specific-networks/mode/explorers.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.mode.network/)"",""[Docs](https://explorer.mode.network/api-docs)""]",mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.mode.network/)"",""[Docs](https://docs.blockscout.com/devs/apis)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/mode)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/soneium/explorers.csv
+++ b/listings/specific-networks/soneium/explorers.csv
@@ -1,4 +1,4 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://soneium.blockscout.com/)"",""[Docs](https://soneium.blockscout.com/api-docs)""]",mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://soneium.blockscout.com/)"",""[Docs](https://docs.blockscout.com/devs/apis)""]",mainnet,,,,,,,,,,,
 okx-mainnet,,!offer:okx,"[""[Explore](https://web3.okx.com/explorer/soneium)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/soneium)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
# data(base/gnosis/mode/soneium): repoint 4 dead `/api-docs` Blockscout links to the live docs.blockscout.com API home

Refs #3343 (full census + adjudication of all 25 dead URLs from this sweep lives there).

## What & why

4 listing rows point their "Docs" action button at `https://<instance>/api-docs`
— the pre-rewrite Blockscout UI path that today 404s on every instance I
measured (HEAD **and** GET, redirects followed, `Mozilla/5.0` UA, system CA):

| row | dead URL | probe |
|---|---|---|
| `listings/specific-networks/base/explorers.csv:5` | base.blockscout.com/api-docs | 404/404 |
| `listings/specific-networks/gnosis/explorers.csv:3` | gnosis-chiado.blockscout.com/api-docs | 404/404 |
| `listings/specific-networks/mode/explorers.csv:2` | explorer.mode.network/api-docs | 404/404 |
| `listings/specific-networks/soneium/explorers.csv:2` | soneium.blockscout.com/api-docs | 404/404 |

Repoint target `https://docs.blockscout.com/devs/apis` — the provider's own API
documentation home: 200, page title "Blockscout APIs - Blockscout", and its
body carries live instance-URL API examples (e.g.
`https://eth.blockscout.com/api/eth-rpc`), so it is topical for all four
instances. Cross-checked fleet-wide: eth.blockscout.com and
zksync.blockscout.com (rows already alive in this repo) 404 `/api-docs` too —
this is a moved path class, not a per-instance outage.

## Rows I deliberately did NOT touch (reasons in #3343)
- `scroll/explorers.csv:3` — scroll.blockscout.com additionally 302s to
  scrollscan.com = the whole listing row may be stale, maintainer call.
- `katana/explorers.csv:2` — explorer.katanarpc.com serves no Blockscout
  marker in its page bytes; won't repoint to Blockscout docs on an
  unverified engine.
- lava/arbitrum x2 (provider-discontinued, rows being rewritten by open
  #3266), `docs.arbitrum.io/sdk` (already repointed by open #3246),
  blockdaemon/aptos x2 + chainbase x2 + okx-soneium + launchcaster +
  chainlink-blast-faucet (alive provider / no provider-published replacement
  — no invented URLs).

Method: HEAD→GET ladder per the link-health protocol (403/429 not counted as
dead; RPC-shaped paths POST-probed before any dead verdict).

Rewards address (per payout rail): 0x5439BC46AC9cc70dfFC500611c6D845d7eE9eE5E
