### PR TITLE
ci(link-check): ignore throttled social hosts and accept HTTP 999 (Closes #3347)

### DIFF
--- a/.github/workflows/link-check-analysis.yaml
+++ b/.github/workflows/link-check-analysis.yaml
@@ -54,7 +54,7 @@ jobs:
                       headers[f] = fp.readline().rstrip("\n")
           
           for p in Path(".").iterdir():
-              if p.name != ".git":
+              if p.name != ".git" and p.name != ".lycheeignore":
                   subprocess.run(["rm","-rf",str(p)])
       
           for f, lines in files.items():
@@ -145,7 +145,7 @@ jobs:
           args: >
             --extensions csv
             --method GET
-            --accept 200,202,204,400,401,403,405,429
+            --accept 200,202,204,400,401,403,405,429,999
             --timeout 15
             --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
             --header "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,6 @@
 rpc*
+x.com
+twitter.com
+linkedin.com
+https?://(www\.)?(twitter|x)\.com/.*
+https?://(www\.)?linkedin\.com/.*


### PR DESCRIPTION
## Summary
Resolves #3347 by:
1. Adding throttled social hosts (`x.com`, `twitter.com`, `linkedin.com`) to `.lycheeignore` to prevent false-positive PR CI gate failures.
2. Preserving `.lycheeignore` in the PR additions materialization step in `.github/workflows/link-check-analysis.yaml`.
3. Adding HTTP `999` to the accepted status codes list in Lychee arguments for bot-blocked responses.

Rewards address: 0x1230bbFDfcDE8A429Fb0926cDAF843D0ADFf7b91 (USDC on Ethereum/EVM)

Closes #3347