### PR TITLE
feat(networks): add canonical networks reference registry (Closes #2961)

### DIFF
--- a/references/networks.csv
+++ b/references/networks.csv
@@ -1,0 +1,11 @@
+network,chain,displayName,caip2,evmChainId,nativeCurrency,status,aliases,source
+somnia,mainnet,Somnia Mainnet,eip155:5031,5031,"{""name"":""Somnia"",""symbol"":""SOMI"",""decimals"":18}",mainnet,[],https://docs.somnia.network/developer/network-info
+filecoin,mainnet,Filecoin Mainnet,eip155:314,314,"{""name"":""Filecoin"",""symbol"":""FIL"",""decimals"":18}",mainnet,[],https://docs.filecoin.io/networks/mainnet
+algorand,mainnet,Algorand Mainnet,algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k,,"{""name"":""Algo"",""symbol"":""ALGO"",""decimals"":6}",mainnet,[],https://namespaces.chainagnostic.org/algorand/caip2
+ethereum,mainnet,Ethereum Mainnet,eip155:1,1,"{""name"":""Ether"",""symbol"":""ETH"",""decimals"":18}",mainnet,[],https://ethereum.org
+arbitrum,mainnet,Arbitrum One,eip155:42161,42161,"{""name"":""Ether"",""symbol"":""ETH"",""decimals"":18}",mainnet,"[""Arbitrum""]",https://docs.arbitrum.io/for-devs/concepts/network-info
+optimism,mainnet,OP Mainnet,eip155:10,10,"{""name"":""Ether"",""symbol"":""ETH"",""decimals"":18}",mainnet,"[""Optimism""]",https://docs.optimism.io/chain/networks
+polygon,mainnet,Polygon PoS Mainnet,eip155:137,137,"{""name"":""POL"",""symbol"":""POL"",""decimals"":18}",mainnet,"[""Matic""]",https://docs.polygon.technology/pos/reference/network-details/network-ports/
+bsc,mainnet,BNB Smart Chain Mainnet,eip155:56,56,"{""name"":""BNB"",""symbol"":""BNB"",""decimals"":18}",mainnet,"[""Binance Smart Chain""]",https://docs.bnbchain.org/bnb-smart-chain/developers/network-info/
+base,mainnet,Base Mainnet,eip155:8453,8453,"{""name"":""Ether"",""symbol"":""ETH"",""decimals"":18}",mainnet,[],https://docs.base.org/network-information/
+solana,mainnet,Solana Mainnet Beta,solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp,,"{""name"":""SOL"",""symbol"":""SOL"",""decimals"":9}",mainnet,[],https://docs.solana.com/clusters


### PR DESCRIPTION
## Summary
Resolves #2961 by adding the canonical network registry `references/networks.csv` with CAIP-2, EIP-155 chain IDs, native currency symbols, and official documentation sources.

Rewards address: 0x1230bbFDfcDE8A429Fb0926cDAF843D0ADFf7b91 (USDC on Ethereum/EVM)

Closes #2961