### PR TITLE
data(arbitrum): remove 2 discontinued Lava public RPC listings (both endpoints HTTP 410)

### DIFF
--- a/listings/specific-networks/arbitrum/apis.csv
+++ b/listings/specific-networks/arbitrum/apis.csv
@@ -226,8 +226,6 @@ infura-sepolia-developer-full-archive,,!offer:infura-developer-full-archive,"[""
 infura-sepolia-developer-recent-state,,!offer:infura-developer-recent-state,"[""[Buy](https://www.infura.io/pricing)"",""[Docs](https://docs.metamask.io/services/reference/arbitrum/)""]",,,,,,sepolia,,,,,,,,,,,,,,,,,,,
 infura-sepolia-team-full-archive,,!offer:infura-team-full-archive,"[""[Buy](https://www.infura.io/pricing)"",""[Docs](https://docs.metamask.io/services/reference/arbitrum/)""]",,,,,,sepolia,,,,,,,,,,,,,,,,,,,
 infura-sepolia-team-recent-state,,!offer:infura-team-recent-state,"[""[Buy](https://www.infura.io/pricing)"",""[Docs](https://docs.metamask.io/services/reference/arbitrum/)""]",,,,,,sepolia,,,,,,,,,,,,,,,,,,,
-lavanetwork-public-one,,!offer:lavanetwork-public-recent-state,"[""[Send requests](https://arbitrum.lava.build/)"",""[Docs](https://docs.lavanet.xyz/public-rpc-endpoints/#arbitrum)""]",,,,,,one,,,,,,,,,,,,,,,,,,,
-lavanetwork-public-sepolia,,!offer:lavanetwork-public-recent-state,"[""[Send requests](https://arbitrums.lava.build/)"",""[Docs](https://docs.lavanet.xyz/public-rpc-endpoints/#arbitrum)""]",,,,,,sepolia,,,,,,,,,,,,,,,,,,,
 mobula-nova-free-indexer,,!offer:mobula-free-indexer,"[""[Website](https://mobula.io/)"",""[Docs](https://docs.mobula.io/blockchains/arbitrum)""]",,,,,,nova,,,,,,,,,,,,,,,,,,,
 mobula-nova-pay-as-you-go-indexer,,!offer:mobula-pay-as-you-go-indexer,"[""[Buy](https://docs.mobula.io/pricing)"",""[Docs](https://docs.mobula.io/blockchains/arbitrum-nova)""]",,,,,,nova,,,,,,,,,,,,,,,,,,,
 mobula-one-free-indexer,,!offer:mobula-free-indexer,"[""[Website](https://mobula.io/)"",""[Docs](https://docs.mobula.io/blockchains/arbitrum)""]",,,,,,one,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Removes the `lavanetwork-public-one` and `lavanetwork-public-sepolia` rows from `listings/specific-networks/arbitrum/apis.csv` — the Lava public Arbitrum RPC endpoints have been discontinued by the provider, so these listings now fail the quality-gateway "providers that no longer exist / broken or dead links" criteria.

This is the direct follow-up to my already-merged #3313 (which removed the Filecoin Lava row of the same shutdown): Lava discontinued their whole public-endpoint lineup except their own chain and Starknet, and the Arbitrum rows were the remaining casualties.

Evidence (verified 2026-08-31):

1. `https://arbitrum.lava.build/` returns **HTTP 410 Gone**, body:
   `{"error":"This endpoint has been discontinued.","message":"For an up to date list of available endpoints, visit https://gateway.lavanet.xyz"}`
2. `https://arbitrums.lava.build/` (the sepolia row's link) returns the same **HTTP 410** with the same discontinuation body.
3. POSTing a valid `eth_chainId` JSON-RPC request to `https://arbitrum.lava.build/` also returns the 410 discontinuation body — the endpoint is gone for JSON-RPC traffic too, not just browser GETs.
4. The docs link used by both rows (`https://docs.lavanet.xyz/public-rpc-endpoints/#arbitrum`) no longer has an Arbitrum section — the rendered page has only `Lava` and `Starknet` headings (I re-fetched the page this cycle: 0 occurrences of "arbitrum" in the HTML), so the `#arbitrum` anchor is dead too.
5. `gateway.lavanet.xyz` (the suggested replacement in the 410 message) redirects to a login page, i.e. there is no signup-free public Arbitrum endpoint from Lava anymore — exactly the situation that justified #3313.
6. The offer record itself stays valid for Starknet (public endpoint still live — `starknet_blockNumber` on `https://rpc.starknet.lava.build` returned a valid JSON-RPC result this cycle: block 14166959), so this PR only removes the two Arbitrum **listings** and leaves `references/offers/apis.csv` and `references/providers/providers.csv` untouched. The starknet folder's `!offer:lavanetwork-public-recent-state` usage remains the sole live consumer.

No other Arbitrum row references this offer after the deletion (`grep` over the file confirms zero remaining hits), so the file stays consistent after the deletion.

## Type of change
- [ ] Add data rows
- [ ] Update data rows
- [x] Remove data rows
- [ ] Schema change <!-- (requires linked DBIP below) -->
- [ ] Documentation/metadata only


## Scope
- Networks affected: arbitrum
- Categories affected: apis

- Additional notes, additional context / screenshots:

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): #3313 (same class, merged)

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
  - Style Guide: https://github.com/Chain-Love/chain-love/wiki/Style-Guide
  - Column Definitions: https://github.com/Chain-Love/chain-love/wiki
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.** (this PR adds no new links; the removed links' death is evidenced above)
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission** — disclosure: this PR was prepared by an autonomous agent, but both endpoint deaths were verified by live HTTP probes (GET + JSON-RPC POST, both 410 with the provider's own discontinuation message), the docs-anchor re-check (0 "arbitrum" occurrences in the live page HTML), and a live JSON-RPC call to the still-working Starknet endpoint to scope the removal correctly. No blind generation; every claim above is reproducible with curl.

## Optional
- Rewards address (for data patching rewards): `0x5439BC46AC9cc70dfFC500611c6D845d7eE9eE5E` (USDC/USDT on Ethereum mainnet)
- Twitter (X) post link (for +10% of rewards to this PR):
