### PR TITLE
fix(explorers): repoint 2 dead Blockscout /api-docs links (katana + scroll) to live Blockscout API docs

### DIFF
--- a/listings/specific-networks/katana/explorers.csv
+++ b/listings/specific-networks/katana/explorers.csv
@@ -1,5 +1,5 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.katanarpc.com/)"",""[Docs](https://explorer.katanarpc.com/api-docs)""]",mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://explorer.katanarpc.com/)"",""[Docs](https://docs.blockscout.com/devs/apis)""]",mainnet,,,,,,,,,,,
 etherscan-mainnet,,!offer:etherscan,"[""[Explore](https://katanascan.com/)"",""[Docs](https://docs.etherscan.io/supported-chains)""]",mainnet,,,,,,,,,,,
 tenderly-explorer-bokuto,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/katana-bokuto)"",""[Docs](https://docs.polygon.technology/interoperability/agglayer/supported-chains)""]",bokuto,,,,,,,,,,,
 tenderly-explorer-mainnet,,!offer:tenderly-explorer,"[""[Explore](https://dashboard.tenderly.co/explorer/katana)"",""[Docs](https://docs.tenderly.co/platform/supported-networks)""]",mainnet,,,,,,,,,,,

--- a/listings/specific-networks/scroll/explorers.csv
+++ b/listings/specific-networks/scroll/explorers.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,chain,technology,monitoringAndAnalytics,additionalFeatures,starred,availableApis,sdk,searchCapabilities,smartContractsVerifications,fullHistory,pricing,tag
 3xpl,,!offer:3xpl,"[""[Explore](https://3xpl.com/scroll)""]",mainnet,,,,,,,,,,,
-blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://scroll.blockscout.com/)"",""[Docs](https://scroll.blockscout.com/api-docs)""]",mainnet,,,,,,,,,,,
+blockscout-mainnet,,!offer:blockscout,"[""[Explore](https://scroll.blockscout.com/)"",""[Docs](https://docs.blockscout.com/devs/apis)""]",mainnet,,,,,,,,,,,
 etherscan-mainnet,,!offer:etherscan,"[""[Explore](https://scrollscan.com/)""]",mainnet,,,,,,,,,,,
 etherscan-testnet,,!offer:etherscan,"[""[Explore](https://sepolia.scrollscan.com/)""]",testnet,,,,,,,,,,,
 oklink-mainnet,,!offer:oklink,"[""[Explore](https://www.oklink.com/scroll)""]",mainnet,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Repoints 2 dead Blockscout explorer `Docs` links (the `/api-docs` page returns HTTP 404 on both instances) to the live Blockscout API docs home `https://docs.blockscout.com/devs/apis`:

- `listings/specific-networks/katana/explorers.csv`: `https://explorer.katanarpc.com/api-docs` -> `https://docs.blockscout.com/devs/apis`
- `listings/specific-networks/scroll/explorers.csv`: `https://scroll.blockscout.com/api-docs` -> `https://docs.blockscout.com/devs/apis`

Evidence (verified 2026-08-31, each fetch repeated x3 with identical results):

1. `https://explorer.katanarpc.com/api-docs` -> **HTTP 404** (page title "katana | Explorer" = app's 404 shell). Its Blockscout API routes are also closed (`/api/v2`, `/api/v2?format=openapi`, `/api/v2/status` all 404), so there is no instance-local docs page to point at — the API docs UI is disabled on this deployment.
2. `https://scroll.blockscout.com/api-docs` -> **HTTP 404**, server title literally `error - page not found | Blockscout` — the provider's own not-found page. The instance's API itself is alive (`/api/v2` answers the JSON-RPC-style router error), this deployment just does not serve the docs page at that path.
3. Method control (same fetch): `https://base.blockscout.com/api-docs` also 404s while `https://explorer.linea.build/api-docs` and `https://explorer.sepolia.linea.build/api-docs` return 200 with real titles — the transport is fine; death is scoped per-deployment. Linea rows stay untouched because they are alive.
4. The replacement `https://docs.blockscout.com/devs/apis` returns **HTTP 200** with title "Blockscout APIs - Blockscout" — the official vendor docs for exactly the API the dead pages used to document. This is the same repoint already proposed for the identical `/api-docs` cell-shape in open PR #3344, so the dataset converges on one replacement class.

## Type of change
- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: katana, scroll
- Categories affected: explorers

- Additional notes: no other row in either file references these two dead URLs (post-edit grep count = 0).

## Links
- Related issue(s)/ DB Improvement Proposal (if schema-related): none (link repair, no schema change)

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.** (replacement verified 200 x3 with real page title, above)
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding** (Blockscout is the provider behind both explorer instances; the replacement is Blockscout's own API docs)
- [x] **This PR is not a blind AI-generated submission** — disclosure: prepared by an autonomous agent; every claim above is a live HTTP measurement reproducible with a single fetch (status codes + server-provided titles, repeated x3).

## Optional
- Rewards address (for data patching rewards): `0x5439BC46AC9cc70dfFC500611c6D845d7eE9eE5E` (USDC/USDT on Ethereum mainnet)
- Twitter (X) post link (for +10% of rewards to this PR):
