### PR TITLE
data(story): add Ankr mainnet and testnet plans

### DIFF
--- a/listings/specific-networks/story/apis.csv
+++ b/listings/specific-networks/story/apis.csv
@@ -1,4 +1,7 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
 alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
-ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/story/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/story/)""]",,,,,,mainnet,,,,,"[""web3"",""net"",""eth""]",,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Buy](https://www.ankr.com/web3-api/chains-list/story/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/story/)""]",,,,,,mainnet,,,,,"[""web3"",""net"",""eth""]",,,,,,,,,,,,,,
+ankr-testnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/story/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/story/)""]",,,,,,testnet,,,,,"[""web3"",""net"",""eth""]",,,,,,,,,,,,,,
+ankr-testnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Buy](https://www.ankr.com/web3-api/chains-list/story/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-api/story/)""]",,,,,,testnet,,,,,"[""web3"",""net"",""eth""]",,,,,,,,,,,,,,
 quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Ankr Story mainnet pay-as-you-go coverage
- add Ankr Story testnet free and pay-as-you-go coverage
- enrich the existing Ankr Story mainnet free row with current official actions and supported API families

## Current-cycle verification
- Ankr's official Story documentation lists both Mainnet and Testnet over HTTPS/WSS and the `web3`, `net`, and `eth` method families.
- `https://rpc.ankr.com/story_mainnet` answered `eth_blockNumber` with HTTP 200 at observed block `0x14a295b`.
- `https://rpc.ankr.com/story_aeneid_testnet` answered `eth_blockNumber` with HTTP 200 at observed block `0x15f4288`.
- The browser-facing Story product and docs URLs both returned HTTP 200.

## Validation
- every CSV row imports with the 29-column Story API schema
- all referenced `!offer:` slugs resolve in `references/offers/apis.csv`
- `git diff --check` passes

Rewards address is intentionally pending; no address was invented.