### PR TITLE
data(core): complete Ankr plan coverage

### DIFF
--- a/listings/specific-networks/core/apis.csv
+++ b/listings/specific-networks/core/apis.csv
@@ -1,4 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
-ankr-mainnet-public-full-archive,,!offer:ankr-public-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/core/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/c-i/#core)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Buy](https://www.ankr.com/web3-api/chains-list/core/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/c-i/#core)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-public-full-archive,,!offer:ankr-public-full-archive,"[""[Website](https://www.ankr.com/web3-api/chains-list/core/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/c-i/#core)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Ankr free and pay-as-you-go recent-state plans for Core mainnet
- add current browser-safe Ankr product and chain-documentation actions to the existing Core public listing

## Verification
- Ankr's current Core documentation lists Core mainnet over HTTPS/WSS and documents the `core` RPC route
- Ankr's current service model supports public/free and pay-as-you-go access
- live `eth_blockNumber` against `https://rpc.ankr.com/core` returned HTTP 200 with result `0x24897e9`
- both browser-facing action URLs return HTTP 200
- CSV parses as 5 rows x 29 fields
- all offer references resolve in `references/offers/apis.csv`
- action-button payloads parse as JSON
- `git diff --check` passes

## Reward address
Pending. No address has been invented or substituted; it can be supplied through the repository's normal reward process when an approved address is available.