### PR TITLE
data(taiko): complete Ankr network plans

### DIFF
--- a/listings/specific-networks/taiko/apis.csv
+++ b/listings/specific-networks/taiko/apis.csv
@@ -1,4 +1,7 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
-ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/rpc/taiko/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/s-t-p3/#taiko)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Buy](https://www.ankr.com/rpc/taiko/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/s-t-p3/#taiko)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-testnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/rpc/taiko/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/s-t-p3/#taiko)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+ankr-testnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Buy](https://www.ankr.com/rpc/taiko/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/s-t-p3/#taiko)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
 goldsky-mainnet-free-indexer,,!offer:goldsky-free-indexer,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-free-recent-state,,!offer:tenderly-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Ankr pay-as-you-go recent-state coverage for Taiko mainnet
- add Ankr free and pay-as-you-go recent-state coverage for the documented Hekla testnet
- add current browser-safe Taiko product and official chain-documentation actions to every Ankr row

## Verification
- Ankr's current Taiko RPC surface identifies mainnet and testnet service
- Ankr's current chain documentation explicitly lists Hekla testnet over HTTPS/WSS
- Ankr's August 2026 infrastructure changelog confirms maintained Taiko mainnet nodes
- live `eth_blockNumber` against `https://rpc.ankr.com/taiko` returned HTTP 200 with result `0xa516b2`
- the documented Hekla route is live and correctly authentication-gated (HTTP 403 without an API token)
- both browser-facing action URLs return HTTP 200
- CSV parses as 6 rows x 29 fields
- all offer references resolve in `references/offers/apis.csv`
- action-button payloads parse as JSON
- `git diff --check` passes

## Reward address
Pending. No address has been invented or substituted; it can be supplied through the repository's normal reward process when an approved address is available.