### PR TITLE
data: complete Ankr X Layer network coverage

### DIFF
--- a/listings/specific-networks/x-layer/apis.csv
+++ b/listings/specific-networks/x-layer/apis.csv
@@ -1,7 +1,10 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
 1rpc-testnet-developer-recent-state,,!offer:1rpc-developer-recent-state,,,,,,,testnet,,,,,,,,,,,,,,,,,,,
 alchemy-mainnet-free-recent-state,,!offer:alchemy-free-recent-state,"[""[Website](https://www.alchemy.com/rpc/xlayer)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
-ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/xlayer/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/x-z/#x-layer)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/xlayer/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/x-z/#x-layer)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-testnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/xlayer/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/x-z/#x-layer)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+ankr-testnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/xlayer/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/x-z/#x-layer)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
 blockdaemon-mainnet-free-recent-state,,!offer:blockdaemon-free-recent-state,"[""[Docs](https://docs.blockdaemon.com/docs/access-xlayer-rpc)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockpi-mainnet-free-recent-state,,!offer:blockpi-free-recent-state,"[""[Website](https://blockpi.io/chain/xlayer)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-free-recent-state,,!offer:tenderly-free-recent-state,"[""[Docs](https://docs.tenderly.co/node/rpc-reference/xlayer)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- repair the existing Ankr X Layer mainnet free entry with current provider actions
- add the missing mainnet pay-as-you-go entry
- add X Layer testnet free and pay-as-you-go entries

## Verification
- Ankr's current X Layer product page and chain docs both return HTTP 200 and document X Layer RPC support
- the documented mainnet and testnet RPC routes are live and correctly auth-gated without a personal token (HTTP 403)
- parsed the CSV with Python: 9 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.