### PR TITLE
data: complete Ankr Gravity network coverage

### DIFF
--- a/listings/specific-networks/gravity/apis.csv
+++ b/listings/specific-networks/gravity/apis.csv
@@ -1,4 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
-ankr-mainnet-public-full-archive,,!offer:ankr-public-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-public-full-archive,,!offer:ankr-public-full-archive,"[""[Website](https://www.ankr.com/web3-api/chains-list/gravity/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/gravity/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/gravity/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/gravity/apis.csv
+++ b/listings/specific-networks/gravity/apis.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
-ankr-mainnet-public-full-archive,,!offer:ankr-public-full-archive,"[""[Website](https://www.ankr.com/web3-api/chains-list/gravity/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/gravity/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/gravity/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-public-full-archive,,!offer:ankr-public-full-archive,"[""[Website](https://www.ankr.com/web3-api/chains-list/gravity/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 quicknode-mainnet-build-recent-state,,!offer:quicknode-build-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- repair the existing Ankr Gravity public entry with current provider actions
- add the missing Gravity mainnet free and pay-as-you-go entries

## Verification
- Ankr's current Gravity product page and general chain documentation both return HTTP 200
- the documented Gravity JSON-RPC route is live and correctly auth-gated without a personal token (HTTP 403)
- parsed the CSV with Python: 5 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.