### PR TITLE
data: add current Ankr actions for Kava

### DIFF
--- a/listings/specific-networks/kava/apis.csv
+++ b/listings/specific-networks/kava/apis.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
-ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
-ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/kava/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/kava/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-free-recent-state,,!offer:drpc-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-pay-as-you-go-recent-state,,!offer:drpc-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-public-recent-state,,!offer:drpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add current Ankr product and documentation actions to both existing Kava mainnet plans
- preserve the existing free and pay-as-you-go offer mappings

## Verification
- Ankr's current Kava product page and chain documentation both return HTTP 200
- Ankr's Kava EVM RPC answered `eth_blockNumber` successfully (HTTP 200)
- parsed the CSV with Python: 5 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.