### PR TITLE
data: add Ankr Gnosis mainnet plans

### DIFF
--- a/listings/specific-networks/gnosis/apis.csv
+++ b/listings/specific-networks/gnosis/apis.csv
@@ -3,6 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free-recent-state,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/gnosis/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go-recent-state,,!offer:ankr-pay-as-you-go-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/gnosis/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-business-full-archive,,!offer:chainstack-business-full-archive,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-business-recent-state,,!offer:chainstack-business-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 chainstack-mainnet-developer-recent-state,,!offer:chainstack-developer-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Ankr's missing Gnosis mainnet free plan
- add Ankr's missing Gnosis mainnet pay-as-you-go plan
- include current provider product and documentation actions

## Verification
- Ankr's current supported-chain index and Gnosis product page confirm active Gnosis support and return HTTP 200
- the Gnosis JSON-RPC route returns HTTP 200 with Ankr's expected authentication-required response when no personal token is supplied
- parsed the CSV with Python: 36 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.