### PR TITLE
data: add current Ankr actions for Flare

### DIFF
--- a/listings/specific-networks/flare/apis.csv
+++ b/listings/specific-networks/flare/apis.csv
@@ -1,8 +1,8 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
-ankr-coston-free,,!offer:ankr-free-recent-state,,,,,,,coston,,,,,,,,,,,,,,,,,,,
-ankr-coston2-free,,!offer:ankr-free-recent-state,,,,,,,coston2,,,,,,,,,,,,,,,,,,,
-ankr-mainnet-free,,!offer:ankr-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
-ankr-mainnet-pay-as-you-go,,!offer:ankr-pay-as-you-go-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-coston-free,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/flare/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,coston,,,,,,,,,,,,,,,,,,,
+ankr-coston2-free,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/flare/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,coston2,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-free,,!offer:ankr-free-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/flare/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+ankr-mainnet-pay-as-you-go,,!offer:ankr-pay-as-you-go-recent-state,"[""[Website](https://www.ankr.com/web3-api/chains-list/flare/)"",""[Docs](https://www.ankr.com/docs/rpc-service/chains/chains-list/)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockeden-mainnet-basic-recent-state,,!offer:blockeden-basic-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockeden-mainnet-enterprise-50-recent-state,,!offer:blockeden-enterprise-50-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 blockeden-mainnet-enterprise-500-recent-state,,!offer:blockeden-enterprise-500-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add current Ankr product and documentation actions to the existing Flare mainnet plans
- add the same current actions to the existing Coston and Coston2 test-network plans
- preserve all existing offer mappings and network labels

## Verification
- Ankr's current Flare product page and chain documentation both return HTTP 200
- Ankr's Flare, Coston, and Coston2 RPC routes each answered `eth_blockNumber` successfully (HTTP 200)
- parsed the CSV with Python: 102 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.