### PR TITLE
data: add Dwellir opBNB mainnet plans

### DIFF
--- a/listings/specific-networks/opbnb/apis.csv
+++ b/listings/specific-networks/opbnb/apis.csv
@@ -3,3 +3,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-personal-recent-state,,!offer:1rpc-personal-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-dedicated-recent-state,,!offer:dwellir-dedicated-recent-state,"[""[Contact](https://www.dwellir.com/contact)"",""[Docs](https://www.dwellir.com/docs/opbnb)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-developer-recent-state,,!offer:dwellir-developer-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/opbnb)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-free-recent-state,,!offer:dwellir-free-recent-state,"[""[Website](https://www.dwellir.com/networks/opbnb)"",""[Docs](https://www.dwellir.com/docs/opbnb)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-growth-recent-state,,!offer:dwellir-growth-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/opbnb)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-scale-recent-state,,!offer:dwellir-scale-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/opbnb)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Dwellir's missing opBNB mainnet free and developer plans
- add the current growth, scale, and dedicated plans
- use Dwellir's opBNB-specific network and documentation surfaces

## Verification
- Dwellir's current opBNB network page, opBNB documentation, pricing, and contact pages all return HTTP 200
- Dwellir's documented opBNB API route is live and correctly auth-gated without a personal key (HTTP 403)
- parsed the CSV with Python: 9 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.