### PR TITLE
data: add Dwellir Berachain plans

### DIFF
--- a/listings/specific-networks/berachain/apis.csv
+++ b/listings/specific-networks/berachain/apis.csv
@@ -1,3 +1,13 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
 berachain-mainnet-public-rpc,,!offer:berachain-public-rpc,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 berachain-testnet-public-rpc,,!offer:berachain-public-rpc,,,,,,,testnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-dedicated-recent-state,,!offer:dwellir-dedicated-recent-state,"[""[Contact](https://www.dwellir.com/contact)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-developer-recent-state,,!offer:dwellir-developer-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-free-recent-state,,!offer:dwellir-free-recent-state,"[""[Website](https://www.dwellir.com/networks/berachain)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-growth-recent-state,,!offer:dwellir-growth-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-scale-recent-state,,!offer:dwellir-scale-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-testnet-dedicated-recent-state,,!offer:dwellir-dedicated-recent-state,"[""[Contact](https://www.dwellir.com/contact)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+dwellir-testnet-developer-recent-state,,!offer:dwellir-developer-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+dwellir-testnet-free-recent-state,,!offer:dwellir-free-recent-state,"[""[Website](https://www.dwellir.com/networks/berachain)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+dwellir-testnet-growth-recent-state,,!offer:dwellir-growth-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,
+dwellir-testnet-scale-recent-state,,!offer:dwellir-scale-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/berachain)""]",,,,,,testnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Dwellir's missing Berachain mainnet free, developer, growth, scale, and dedicated plans
- add the corresponding Bepolia testnet plans
- use Dwellir's current Berachain network and chain-specific documentation surfaces

## Verification
- Dwellir's current Berachain network page, documentation, pricing, and contact pages all return HTTP 200
- the documentation explicitly identifies mainnet and Bepolia testnet routes
- both documented Dwellir routes are live and correctly auth-gated without a personal key (HTTP 403)
- parsed the CSV with Python: 12 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.