### PR TITLE
data: add Dwellir Boba mainnet plans

### DIFF
--- a/listings/specific-networks/boba/apis.csv
+++ b/listings/specific-networks/boba/apis.csv
@@ -1,5 +1,10 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,"[""[Docs](https://docs.1rpc.io/using-the-web3-api/networks)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-dedicated-recent-state,,!offer:dwellir-dedicated-recent-state,"[""[Contact](https://www.dwellir.com/contact)"",""[Docs](https://www.dwellir.com/docs/boba)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-developer-recent-state,,!offer:dwellir-developer-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/boba)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-free-recent-state,,!offer:dwellir-free-recent-state,"[""[Website](https://www.dwellir.com/)"",""[Docs](https://www.dwellir.com/docs/boba)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-growth-recent-state,,!offer:dwellir-growth-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/boba)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-scale-recent-state,,!offer:dwellir-scale-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/boba)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 subquery-mainnet-pay-as-you-go-indexer,,!offer:subquery-pay-as-you-go-indexer,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-dedicated-recent-state,,!offer:tenderly-dedicated-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 tenderly-mainnet-free-recent-state,,!offer:tenderly-free-recent-state,"[""[Docs](https://docs.tenderly.co/node/rpc-reference/boba-ethereum-mainnet)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Dwellir's missing Boba mainnet free and developer plans
- add the current growth, scale, and dedicated plans
- use Dwellir's current Boba-specific documentation

## Verification
- Dwellir's current Boba documentation, product site, pricing, and contact pages all return HTTP 200
- Dwellir's documented Boba mainnet API route is live and correctly auth-gated without a personal key (HTTP 403)
- parsed the CSV with Python: 12 rows, all 29 schema fields
- parsed every non-empty `actionButtons` value as JSON
- resolved every `!offer:` reference against `references/offers/apis.csv`
- `git diff --check` passes

Signed-off-by is included in the commit for DCO compliance.

Reward address: pending; no payout address is being asserted in this contribution.