### PR TITLE
data: add Dwellir Manta Pacific API plans

### DIFF
--- a/listings/specific-networks/manta/apis.csv
+++ b/listings/specific-networks/manta/apis.csv
@@ -1,3 +1,8 @@
 slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,technology,chain,accessPrice,queryPrice,starred,trial,availableApis,limitations,securityImprovements,monitoringAndAnalytics,regions,additionalFeatures,address,tag,uptimeSla,verifiedUptime,blocksBehindSla,verifiedBlocksBehindAvg,bandwidthSla,verifiedLatency,supportSla
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 drpc-mainnet-free-recent-state,,!offer:drpc-free-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-dedicated-recent-state,,!offer:dwellir-dedicated-recent-state,"[""[Contact](https://www.dwellir.com/contact)"",""[Docs](https://www.dwellir.com/docs/manta-pacific)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-developer-recent-state,,!offer:dwellir-developer-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/manta-pacific)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-free-recent-state,,!offer:dwellir-free-recent-state,"[""[Website](https://www.dwellir.com/networks/manta-pacific)"",""[Docs](https://www.dwellir.com/docs/manta-pacific)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-growth-recent-state,,!offer:dwellir-growth-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/manta-pacific)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-scale-recent-state,,!offer:dwellir-scale-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/manta-pacific)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Dwellir's current Manta Pacific mainnet API coverage for the Free, Developer, Growth, Scale, and Dedicated plans
- reuse the canonical Dwellir offer records already present in `references/offers/apis.csv`
- link each row to Dwellir's current Manta Pacific documentation and the appropriate official website, pricing, or contact surface

## Official evidence
- Manta Pacific network/API surface: https://www.dwellir.com/networks/manta-pacific
- Manta Pacific JSON-RPC documentation (chain ID 169): https://www.dwellir.com/docs/manta-pacific
- current plan pricing: https://www.dwellir.com/pricing
- dedicated-plan contact: https://www.dwellir.com/contact

All four official URLs returned HTTP 200 during verification on 2026-09-01.

## Validation
- parsed the CSV with Python's `csv.DictReader`; every row has the exact 29-column schema
- parsed every new `actionButtons` value as JSON
- resolved every new `!offer:` reference against `references/offers/apis.csv`
- confirmed exactly five distinct Dwellir rows were added
- `git diff --check` passes
- commit includes DCO sign-off

## Reward address
An ETH-network USDC/USDT reward address will be supplied separately after owner confirmation; no address is invented or included here.