### PR TITLE
data: add Dwellir Tempo API plans

### DIFF
--- a/listings/specific-networks/tempo/apis.csv
+++ b/listings/specific-networks/tempo/apis.csv
@@ -4,3 +4,8 @@ slug,provider,offer,actionButtons,planName,planType,historicalData,apiType,techn
 1rpc-mainnet-public-recent-state,,!offer:1rpc-public-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-mainnet-starter-recent-state,,!offer:1rpc-starter-recent-state,,,,,,,mainnet,,,,,,,,,,,,,,,,,,,
 1rpc-testnet-developer-recent-state,,!offer:1rpc-developer-recent-state,,,,,,,testnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-dedicated-recent-state,,!offer:dwellir-dedicated-recent-state,"[""[Contact](https://www.dwellir.com/contact)"",""[Docs](https://www.dwellir.com/docs/tempo)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-developer-recent-state,,!offer:dwellir-developer-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/tempo)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-free-recent-state,,!offer:dwellir-free-recent-state,"[""[Website](https://www.dwellir.com/networks/tempo)"",""[Docs](https://www.dwellir.com/docs/tempo)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-growth-recent-state,,!offer:dwellir-growth-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/tempo)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,
+dwellir-mainnet-scale-recent-state,,!offer:dwellir-scale-recent-state,"[""[Buy](https://www.dwellir.com/pricing)"",""[Docs](https://www.dwellir.com/docs/tempo)""]",,,,,,mainnet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- add Dwellir's current Tempo mainnet API coverage
- include Free, Developer, Growth, Scale, and Dedicated plan variants
- reuse the canonical Dwellir offer records already present in `references/offers/apis.csv`

## Official evidence
- Dwellir Tempo mainnet endpoint (chain ID 4217): https://www.dwellir.com/networks/tempo
- Dwellir Tempo JSON-RPC documentation: https://www.dwellir.com/docs/tempo
- current plan pricing: https://www.dwellir.com/pricing
- dedicated-plan contact: https://www.dwellir.com/contact

All four official URLs returned HTTP 200 during verification on 2026-09-01.

## Validation
- parsed the CSV with Python's `csv.DictReader`; every row has the exact 29-column schema
- parsed every new `actionButtons` value as JSON
- resolved every new `!offer:` reference against `references/offers/apis.csv`
- confirmed exactly five distinct Dwellir mainnet rows
- `git diff --check` passes and the diff is exactly 5 insertions
- commit includes DCO sign-off

## Reward address
An ETH-network USDC/USDT reward address will be supplied separately after owner confirmation; no address is invented or included here.