### PR TITLE
fix(analytics): rename historicalData column to historyDepth (Closes #3203)

### DIFF
--- a/listings/all-networks/analytics.csv
+++ b/listings/all-networks/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-enterprise,,!offer:coingecko-api-enterprise,,,,,,,,,,,
 cryptoquant-enterprise,,!offer:cryptoquant-enterprise,,,,,,,,,,,
 defillama-enterprise,,!offer:defillama-enterprise,,,,,,,,,,,

--- a/listings/specific-networks/algorand/analytics.csv
+++ b/listings/specific-networks/algorand/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 algorand-metrics-dashboard-mainnet,Algorand,,"[""[Dashboard](https://algorand.co/metrics)""]",mainnet,"[""Transactions"",""Network Metrics"",""Active Addresses"",""Block Data"",""Performance Metrics""]",TRUE,,"[""Real-time Metrics API"",""Network Status API""]",$0,,Free,FALSE,
 allo-mainnet,Allo,,"[""[Dashboard](https://metrics.allo.info/)""]",mainnet,"[""Transactions"",""Assets"",""Apps"",""Blocks"",""Accounts"",""NFDomains"",""TEAL Contracts""]",TRUE,,"[""TEAL Inspector API"",""Account API"",""Asset API""]",$0,,Free,FALSE,
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/algorand)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/aptos/analytics.csv
+++ b/listings/specific-networks/aptos/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 blockworks-mainnet,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/aptos)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/arbitrum/analytics.csv
+++ b/listings/specific-networks/arbitrum/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/arbitrum?from=assets)""]",one,,,,,,,,,
 blockworks,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/arbitrum)""]",one,,,,,,,,,
 chainspect-one,,!offer:chainspect,"[""[Dashboard](https://chainspect.app/chain/arbitrum)""]",one,,,,,,,,,

--- a/listings/specific-networks/astar/analytics.csv
+++ b/listings/specific-networks/astar/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,astar,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,astar,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,astar,,,,,,,,,

--- a/listings/specific-networks/avalanche/analytics.csv
+++ b/listings/specific-networks/avalanche/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 arkham,,!offer:arkham,"[""[Dashboard](https://intel.arkm.com/explorer/entity/avalanche)""]",mainnet,,,,,,,,,
 artemis,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/avalanche?from=assets)""]",mainnet,,,,,,,,,
 blockworks,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/avalanche)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/base/analytics.csv
+++ b/listings/specific-networks/base/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 blockworks-mainnet,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/base)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/berachain/analytics.csv
+++ b/listings/specific-networks/berachain/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/bitcoin-cash/analytics.csv
+++ b/listings/specific-networks/bitcoin-cash/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/bitcoin/analytics.csv
+++ b/listings/specific-networks/bitcoin/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/blast/analytics.csv
+++ b/listings/specific-networks/blast/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/blast?tab=overview)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/boba/analytics.csv
+++ b/listings/specific-networks/boba/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/boba)""]",mainnet,,,,,,,,,
 l2beat-mainnet,,!offer:l2beat,"[""[Dashboard](https://l2beat.com/scaling/projects/bobanetwork)""]",mainnet,,,,,,,,,
 tokenterminal-mainnet,,!offer:tokenterminal,"[""[Dashboard](https://tokenterminal.com/explorer/projects/boba-network)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/bsc/analytics.csv
+++ b/listings/specific-networks/bsc/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,,mainnet,,,,,,,,,
 blockworks,,!offer:blockworks,,mainnet,,,,,,,,,
 bscscan-analytics,Etherscan,,"[""[Dashboard](https://bscscan.com/charts)""]",mainnet,"[""Transactions"",""Gas"",""Accounts"",""Network""]",TRUE,,"[""REST API""]",Free,,Free,TRUE,

--- a/listings/specific-networks/cardano/analytics.csv
+++ b/listings/specific-networks/cardano/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/celo/analytics.csv
+++ b/listings/specific-networks/celo/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/corn/analytics.csv
+++ b/listings/specific-networks/corn/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 dune-mainnet-analyst,,!offer:dune-analyst,"[""[Dashboard](https://dune.com/blockchains/corn)""]",mainnet,,,,,,,,,
 dune-mainnet-free,,!offer:dune-free,"[""[Dashboard](https://dune.com/blockchains/corn)""]",mainnet,,,,,,,,,
 dune-mainnet-plus,,!offer:dune-plus,"[""[Dashboard](https://dune.com/blockchains/corn)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/cronos/analytics.csv
+++ b/listings/specific-networks/cronos/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/dash/analytics.csv
+++ b/listings/specific-networks/dash/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/dogecoin/analytics.csv
+++ b/listings/specific-networks/dogecoin/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/ethereum-classic/analytics.csv
+++ b/listings/specific-networks/ethereum-classic/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/ethereum/analytics.csv
+++ b/listings/specific-networks/ethereum/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/ethereum?tab=overview)""]",mainnet,,,,,,,,,
 blockworks-mainnet,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/ethereum)""]",mainnet,,,,,,,,,
 chainspect-mainnet,,!offer:chainspect,"[""[Dashboard](https://chainspect.app/chain/ethereum)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/fantom/analytics.csv
+++ b/listings/specific-networks/fantom/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/filecoin/analytics.csv
+++ b/listings/specific-networks/filecoin/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 cid-checker-calibnet,,!offer:cid-checker,,calibnet,,,,,,,,,
 cid-checker-mainnet,,!offer:cid-checker,,mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,

--- a/listings/specific-networks/flare/analytics.csv
+++ b/listings/specific-networks/flare/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/fraxtal/analytics.csv
+++ b/listings/specific-networks/fraxtal/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/gnosis/analytics.csv
+++ b/listings/specific-networks/gnosis/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/gnosis)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/hyperevm/analytics.csv
+++ b/listings/specific-networks/hyperevm/analytics.csv
@@ -1,2 +1,2 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 dune-mainnet-free,,!offer:dune-free,"[""[Dashboard](https://dune.com/blockchains/hyperevm)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/hyperliquid/analytics.csv
+++ b/listings/specific-networks/hyperliquid/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://app.artemis.xyz/project/hyperliquid)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/perps/chains/hyperliquid)""]",mainnet,,,,,,,,,
 dune-mainnet-free,,!offer:dune-free,"[""[Dashboard](https://dune.com/mogie/hyperliquid-flows)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/ink/analytics.csv
+++ b/listings/specific-networks/ink/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/iotex/analytics.csv
+++ b/listings/specific-networks/iotex/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/kaspa/analytics.csv
+++ b/listings/specific-networks/kaspa/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/katana/analytics.csv
+++ b/listings/specific-networks/katana/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-free,,!offer:defillama-free,,mainnet,,,,,,,,,
 dexscreener,,!offer:dexscreener,,mainnet,,,,,,,,,
 dune-free,,!offer:dune-free,,mainnet,,,,,,,,,

--- a/listings/specific-networks/lens/analytics.csv
+++ b/listings/specific-networks/lens/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/lens)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/lens)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/lens)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/linea/analytics.csv
+++ b/listings/specific-networks/linea/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/linea?tab=overview)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/litecoin/analytics.csv
+++ b/listings/specific-networks/litecoin/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/mantle/analytics.csv
+++ b/listings/specific-networks/mantle/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/mantle?tab=overview)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/merlin/analytics.csv
+++ b/listings/specific-networks/merlin/analytics.csv
@@ -1,3 +1,3 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-free,,!offer:defillama-free,,mainnet,,,,,,,,,
 footprint-analytics-mainnet-free,,!offer:footprint-analytics-free,,mainnet,,,,,,,,,

--- a/listings/specific-networks/metis/analytics.csv
+++ b/listings/specific-networks/metis/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/mode/analytics.csv
+++ b/listings/specific-networks/mode/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/mode?tab=overview)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/monad/analytics.csv
+++ b/listings/specific-networks/monad/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,"[""[Dashboard](https://app.artemisanalytics.com/asset/monad?from=assets)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/moonbeam/analytics.csv
+++ b/listings/specific-networks/moonbeam/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/opbnb/analytics.csv
+++ b/listings/specific-networks/opbnb/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/opbnb)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/opbnb)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/opbnb)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/optimism/analytics.csv
+++ b/listings/specific-networks/optimism/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 blockworks-mainnet,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/optimism)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/plasma/analytics.csv
+++ b/listings/specific-networks/plasma/analytics.csv
@@ -1,3 +1,3 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 dune-mainnet-free,,!offer:dune-free,,mainnet,,,,,,,,,
 tokenterminal-mainnet,,!offer:tokenterminal,,mainnet,,,,,,,,,

--- a/listings/specific-networks/plume/analytics.csv
+++ b/listings/specific-networks/plume/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/plume)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/plume-mainnet)""]",mainnet,,,,,,,,,
 dune-mainnet-free,,!offer:dune-free,,mainnet,,,,,,,,,

--- a/listings/specific-networks/polygon/analytics.csv
+++ b/listings/specific-networks/polygon/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-polygon,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/polygon)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/ronin/analytics.csv
+++ b/listings/specific-networks/ronin/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/ronin)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/ronin)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/ronin)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/rootstock/analytics.csv
+++ b/listings/specific-networks/rootstock/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/rootstock)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/rootstock)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/rootstock)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/scroll/analytics.csv
+++ b/listings/specific-networks/scroll/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/scroll)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/secret/analytics.csv
+++ b/listings/specific-networks/secret/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/secret)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/secret)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/secret)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/sei/analytics.csv
+++ b/listings/specific-networks/sei/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/shape/analytics.csv
+++ b/listings/specific-networks/shape/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/shape)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/shape)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/shape)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/solana/analytics.csv
+++ b/listings/specific-networks/solana/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/solana)""]",mainnet,,,,,,,,,
 blockworks-mainnet,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/solana)""]",mainnet,,,,,,,,,
 bubblemaps-mainnet,,!offer:bubblemaps,"[""[Dashboard](https://v2.bubblemaps.io/solana)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/somnia/analytics.csv
+++ b/listings/specific-networks/somnia/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 chainspect-mainnet,,!offer:chainspect,"[""[Dashboard](https://chainspect.app/chain/somnia)""]",mainnet,"[""Real-time TPS"",""Max TPS"",""Transaction Volume"",""Block Time"",""Finality"",""Total Transactions"",""Nakamoto Coefficient"",""Validators"",""Financial Metrics""]",,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/soneium/analytics.csv
+++ b/listings/specific-networks/soneium/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/soneium)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/soneium)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/soneium)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/sonic/analytics.csv
+++ b/listings/specific-networks/sonic/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/sophon/analytics.csv
+++ b/listings/specific-networks/sophon/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/sophon)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/sophon)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/sophon)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/stacks/analytics.csv
+++ b/listings/specific-networks/stacks/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/stargaze/analytics.csv
+++ b/listings/specific-networks/stargaze/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/stargaze)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/stargaze)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/stargaze)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/starknet/analytics.csv
+++ b/listings/specific-networks/starknet/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis-mainnet,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/starknet)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/starknet)""]",mainnet,,,,,,,,,
 footprint-analytics-mainnet-free,,!offer:footprint-analytics-free,"[""[Dashboard](https://www.footprint.network/research/chain/non-evm-stats/starknet-overview)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/stellar/analytics.csv
+++ b/listings/specific-networks/stellar/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/stride/analytics.csv
+++ b/listings/specific-networks/stride/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/stride)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/stride)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/stride)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/sui/analytics.csv
+++ b/listings/specific-networks/sui/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 artemis,,!offer:artemis,"[""[Dashboard](https://classic.artemis.ai/asset/sui)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/superposition/analytics.csv
+++ b/listings/specific-networks/superposition/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/superposition)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/superposition)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/superposition)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/superseed/analytics.csv
+++ b/listings/specific-networks/superseed/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/superseed)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/superseed)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/superseed)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/taiko/analytics.csv
+++ b/listings/specific-networks/taiko/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/telos/analytics.csv
+++ b/listings/specific-networks/telos/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/telos)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/telos)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/telos)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/tempo/analytics.csv
+++ b/listings/specific-networks/tempo/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/tempo)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/tempo)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/tempo)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/tezos/analytics.csv
+++ b/listings/specific-networks/tezos/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/ton/analytics.csv
+++ b/listings/specific-networks/ton/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/tron/analytics.csv
+++ b/listings/specific-networks/tron/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/unichain/analytics.csv
+++ b/listings/specific-networks/unichain/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/unichain)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/unichain)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/unichain)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/vana/analytics.csv
+++ b/listings/specific-networks/vana/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/vana)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/vana)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/vana)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/vechain/analytics.csv
+++ b/listings/specific-networks/vechain/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 defillama-mainnet-api,,!offer:defillama-api,"[""[Dashboard](https://defillama.com/chain/vechain)""]",mainnet,,,,,,,,,
 defillama-mainnet-free,,!offer:defillama-free,"[""[Dashboard](https://defillama.com/chain/vechain)""]",mainnet,,,,,,,,,
 defillama-mainnet-pro,,!offer:defillama-pro,"[""[Dashboard](https://defillama.com/chain/vechain)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/world-chain/analytics.csv
+++ b/listings/specific-networks/world-chain/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 dune-mainnet-analyst,,!offer:dune-analyst,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,
 dune-mainnet-free,,!offer:dune-free,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,
 dune-mainnet-plus,,!offer:dune-plus,"[""[Dashboard](https://dune.com/blockchains/worldchain)""]",mainnet,,,,,,,,,

--- a/listings/specific-networks/xrpl/analytics.csv
+++ b/listings/specific-networks/xrpl/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/listings/specific-networks/zcash/analytics.csv
+++ b/listings/specific-networks/zcash/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 blockworks,,!offer:blockworks,"[""[Dashboard](https://blockworks.com/analytics/zcash)""]",mainnet,,,,,,,,,
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,

--- a/listings/specific-networks/zksync/analytics.csv
+++ b/listings/specific-networks/zksync/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,chain,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 coingecko-api-analyst,,!offer:coingecko-api-analyst,,mainnet,,,,,,,,,
 coingecko-api-basic,,!offer:coingecko-api-basic,,mainnet,,,,,,,,,
 coingecko-api-lite,,!offer:coingecko-api-lite,,mainnet,,,,,,,,,

--- a/references/offers/analytics.csv
+++ b/references/offers/analytics.csv
@@ -1,4 +1,4 @@
-slug,provider,offer,actionButtons,dataSources,hasDashboard,historicalData,availableApis,price,planName,planType,starred,tag
+slug,provider,offer,actionButtons,dataSources,hasDashboard,historyDepth,availableApis,price,planName,planType,starred,tag
 arkham,Arkham,,"[""[Dashboard](https://arkm.com/register?ref=aee358ba-e4d6-455a-a6e0-741243247160)""]","[""Transactions"",""Active Users"",""Contracts"",""DApp Interactions""]",TRUE,,"[""REST API"",""WebSocket API"",""Arkham Exchange API""]",Custom,,Enterprise,FALSE,
 artemis,Artemis,,"[""[Dashboard](https://www.artemis.ai/home)""]","[""On-chain Metrics"",""Financial Metrics"",""Developer Activity"",""Application Activity"",""Stablecoin Metrics""]",TRUE,,,$0,Lite,Free,FALSE,
 blockworks,Blockworks,,"[""[Dashboard](https://blockworks.com/analytics/chain-comparison)""]","[""Network fees"",""Transaction activity"",""Contracts deployed"",""Tokens created"",""Retention rate"",""Economics per defi type"",""AI Agents"",""Stablecoins swaps"",""Meme coins""]",TRUE,,"[""Data API"",""Supported Data Types"",""Additional Tools and Libraries""]",$0,,Free,FALSE,


### PR DESCRIPTION
## Summary
Resolves #3203 by renaming `historicalData` to `historyDepth` in `references/offers/analytics.csv` and all 78 network listing tables to eliminate the semantic overlap with RPC data-retention mode in `apis.csv`.

Rewards address: 0x1230bbFDfcDE8A429Fb0926cDAF843D0ADFf7b91 (USDC on Ethereum/EVM)

Closes #3203