### PR TITLE
data(ethereum): list wevm ABIType SDK

### DIFF
--- a/listings/specific-networks/ethereum/sdks.csv
+++ b/listings/specific-networks/ethereum/sdks.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,toolType,programmingLanguage,tag,description,planType,planName,price,trial,starred,dependencies,latestKnownVersion,latestKnownReleaseDate,maintainer,license
 0x-cert,,!offer:0x-cert,,,,,,,,,,,,,,,
+abitype,,!offer:abitype,,,,,,,,,,,,,,,
 alchemy-sdk-free,,!offer:alchemy-sdk-free,,,,,,,,,,,,,,,
 alchemy-sdk-pay-as-you-go,,!offer:alchemy-sdk-pay-as-you-go,,,,,,,,,,,,,,,
 alloy,,!offer:alloy,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Lists wevm's ABIType library for Ethereum. The canonical ABIType offer already exists, but it is not currently listed for Ethereum despite providing strict TypeScript types and utilities specifically for Ethereum ABIs.

## Verification

- Official project: https://github.com/wevm/abitype
- Official docs: https://abitype.dev/
- Current release verified: abitype@1.3.0
- Repository is active, MIT licensed, and maintained by wevm
- Existing canonical offer is reused through `!offer:abitype`
- CSV width matches its 18-column header
- Slugs are case-insensitively sorted and unique
- `git diff --check` passes
- No existing Ethereum ABIType listing or open PR adding it was found; open #3375 updates offer metadata only

Reward address: pending — no authorized public EVM receiving address is configured.