### PR TITLE
data(somnia): add BitGo wallet listings

### DIFF
--- a/listings/specific-networks/somnia/wallets.csv
+++ b/listings/specific-networks/somnia/wallets.csv
@@ -1,6 +1,9 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 ambire-wallet,,!offer:ambire-wallet,,,,,,,,,,,,,,,,,,,
 binance-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
+bitgo-cold-wallet,,!offer:bitgo-cold-wallet,,,,,,,,,,,,,,,,,,,
+bitgo-custody-wallet,,!offer:bitgo-custody-wallet,,,,,,,,,,,,,,,,,,,
+bitgo-hot-wallet,,!offer:bitgo-hot-wallet,,,,,,,,,,,,,,,,,,,
 clave-wallet,,!offer:clave-wallet,,,,,,,,,,,,,,,,,,,
 coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
 coinomi-wallet,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
Adds the existing canonical BitGo cold, custody, and hot wallet offers to Somnia.

## Evidence
- Somnia lists BitGo as a live wallet in its current ecosystem: https://somnia.network/ecosystem
- BitGo cold wallets: https://www.bitgo.com/products/cold-wallets/
- BitGo qualified custody wallets: https://www.bitgo.com/products/custody-wallets/
- BitGo hot wallets: https://www.bitgo.com/products/hot-wallets/

## Validation
- `python validate_csv.py` — passed
- `python csv_to_json.py` — passed
- `python validate.py` — passed, including `somnia.json`
- 22-column schema, A-Z slug order, and duplicate-slug checks — passed
- Change is limited to one file and three rows
- Reuses the existing canonical `bitgo` provider and `bitgo-cold-wallet`, `bitgo-custody-wallet`, and `bitgo-hot-wallet` offers
- No existing BitGo Somnia listing or exact competing issue/PR found

## Rewards
Ethereum mainnet USDC/USDT reward address: pending account-owner confirmation. No address has been invented or reused from an unrelated account.

---
Reward address (USDC/USDT, Ethereum mainnet): `0xd2b19220877be4d3ff5c51a99b63c545ad73101f`
