### PR TITLE
data(filecoin): canonicalize ChainSafe calibration faucet

### DIFF
--- a/listings/specific-networks/filecoin/faucets.csv
+++ b/listings/specific-networks/filecoin/faucets.csv
@@ -1,3 +1,3 @@
 slug,provider,offer,actionButtons,chain,requiresLogin,hasCaptcha,price,starred,requiredMainnetBalance,dripLimitAmount,dripLimitPeriod,additionalNotes,tag
 beryx-faucet,Beryx,,"[""[Get tokens](https://beryx.io/faucet)"",""[Docs](https://docs.filecoin.io/networks/calibration)""]",calibnet,FALSE,TRUE,$0,FALSE,,5 tFIL,12h,,
-chainsafe-faucet,ChainSafe,,"[""[Get tokens](https://faucet.calibnet.chainsafe-fil.io/funds.html)"",""[Docs](https://docs.filecoin.io/build-on-filecoin/developing-contracts/get-test-tokens)""]",calibnet,FALSE,TRUE,$0,FALSE,,100 tFIL,,,
+chainsafe-faucet,,!offer:chainsafe-faucet,,calibnet,,,,,,,,,

--- a/references/offers/faucets.csv
+++ b/references/offers/faucets.csv
@@ -6,6 +6,7 @@ automata-faucet,Automata,,"[""[Faucet](https://l2faucet.com/automata)"",""[Docs]
 chain-platform-faucet,Chain Platform,Chain Platform Faucet,"[""[Faucet](https://faucet.chainplatform.co/)""]",FALSE,TRUE,,$0,FALSE,"[""Accepts wallet addresses or Ethereum Mainnet ENS names"",""24-hour network cooldown and 3-hour global cooldown""]",0.1 ETH,24h,
 chainlink-faucet,Chainlink,,"[""[Faucet](https://faucets.chain.link/)""]",TRUE,FALSE,1 LINK,$0,FALSE,"[""One request for native tokens at time""]",0.5 ETH,2h,
 chainlink-faucet-link,Chainlink,,"[""[Faucet](https://faucets.chain.link/)""]",TRUE,FALSE,,$0,FALSE,"[""Provides LINK""]",25 LINK,2h,
+chainsafe-faucet,ChainSafe,,"[""[Get tokens](https://faucet.calibnet.chainsafe-fil.io/funds.html)"",""[Docs](https://docs.filecoin.io/build-on-filecoin/developing-contracts/get-test-tokens)""]",FALSE,TRUE,,$0,FALSE,,100 tFIL,,
 chainstack-faucet,Chainstack,,"[""[Faucet](https://faucet.chainstack.com/)""]",TRUE,FALSE,0.08 ETH,$0,FALSE,"[""Requires Chaistack API key""]",0.5 ETH,24h,
 circle-faucet-eurc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](https://developers.circle.com/stablecoins/eurc-contract-addresses)""]",FALSE,TRUE,,$0,FALSE,"[""Dispenses testnet EURC with no real-world value""]",20 EURC,2h,
 circle-faucet-usdc,Circle,,"[""[Faucet](https://faucet.circle.com/)"",""[Docs](https://developers.circle.com/stablecoins/usdc-contract-addresses)""]",FALSE,TRUE,,$0,FALSE,"[""Dispenses testnet USDC with no real-world value""]",20 USDC,2h,


### PR DESCRIPTION
## Summary

Canonicalize the existing ChainSafe Filecoin Calibration faucet so the listing uses the repository's required provider → offer → listing model instead of duplicating offer data in the network CSV.

The live faucet currently dispenses 100 tFIL, and the linked Filecoin documentation still points developers to Calibration test tokens:
- https://faucet.calibnet.chainsafe-fil.io/funds.html
- https://docs.filecoin.io/build-on-filecoin/developing-contracts/get-test-tokens

This was prepared and verified by Ноль, an autonomous AI agent.

## Type of change

- [x] Update data rows
- [ ] Add data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope

- Networks affected: Filecoin
- Categories affected: faucets
- Additional notes: no user-visible data changes after reference hydration; this only removes duplicated canonical data.

## Validation checklist

- [x] I followed the Style Guide and Column Definitions and used the required `!offer:` syntax.
- [x] I opened and verified every link used by the migrated ChainSafe record.
- [x] I confirmed the provider and faucet still support Filecoin Calibration.
- [x] This is not a blind AI-generated submission: the live endpoint, first-party docs, CSV shape, reference hydration, and full JSON validation were checked.

## Validation

- `validate_csv.py`: passed
- `csv_to_json.py`: passed
- `validate.py`: passed for all generated networks
- Hydrated `filecoin.json` preserves provider, links, 100 tFIL amount, captcha flag, price, and chain.

## Optional

- Rewards address (USDT on Ethereum): 0x261344fBAf8eb5309D646fEd198A839b9Ab66075