### PR TITLE
fix(schema): rename explorer pricing to price (#2481)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -351,17 +351,6 @@
     "cellType": null,
     "group": "capabilities"
   },
-  "pricing": {
-    "key": "pricing",
-    "label": "Pricing",
-    "icon": "lucide:BadgeDollarSign",
-    "description": "Pricing model/notes.",
-    "filter": "searchableMultiSelect",
-    "sorting": "string",
-    "pinning": null,
-    "cellType": null,
-    "group": "pricing"
-  },
   "dataTypes": {
     "key": "dataTypes",
     "label": "Data Types",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -160,7 +160,7 @@
         },
         "smartContractsVerifications": { "type": "boolean" },
         "fullHistory": { "type": "boolean" },
-        "pricing": { "type": ["string", "null"] },
+        "price": { "type": ["string", "null"] },
         "actionButtons": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -180,7 +180,7 @@
         "searchCapabilities",
         "smartContractsVerifications",
         "fullHistory",
-        "pricing",
+        "price",
         "actionButtons",
         "tag"
       ]


### PR DESCRIPTION
## Summary
Unblocks approved DBIP #2481 by aligning the explorer schema with the shared `price` column before the main-branch CSV rename.

## Changes
- `tools/schema.json`: rename explorer property `pricing` to `price`
- `tools/schema.json`: rename the matching required key
- `meta/columns.json`: remove the now-redundant explorer-only `pricing` metadata; shared `price` metadata already exists

## Validation
- Both JSON files parse successfully
- Every explorer required key is present in explorer properties
- `price` exists in schema and metadata; `pricing` no longer exists there
- `git diff --check` passes

This intentionally targets `json-tools` first. After merge, a separate data PR against `main` can perform the header-only rename without the CI ordering failure described in #2481.

## Payout
Approved DBIP #2481: 10 USDC to `0x06f44f4839fd5df4f4670036d028b29dec939363`.
