### PR TITLE
feat(bridges): validate supported route metadata (#2624)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -450,6 +450,17 @@
     "cellType": "arrayPopover",
     "group": "capabilities"
   },
+  "supportedRoutes": {
+    "key": "supportedRoutes",
+    "label": "Supported Routes",
+    "icon": "lucide:Route",
+    "description": "Verified ordered source-to-destination bridge routes.",
+    "filter": "none",
+    "sorting": "arrayLength",
+    "pinning": null,
+    "cellType": "arrayPopover",
+    "group": "capabilities"
+  },
   "price": {
     "key": "price",
     "label": "Price",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -261,6 +261,25 @@
           "type": ["array", "null"],
           "items": { "type": "string" }
         },
+        "supportedRoutes": {
+          "type": ["array", "null"],
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["sourceChain", "destinationChain"],
+            "properties": {
+              "sourceChain": { "type": "string", "minLength": 1 },
+              "destinationChain": { "type": "string", "minLength": 1 },
+              "assetSymbols": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        },
         "starred": { "type": "boolean" },
         "availableApis": {
           "type": ["array", "null"],

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -95,6 +95,65 @@ def rule_chain_is_lowercase(data):
             errors.append(f"Item {idx}: chain must be lowercase: want '{item['chain'].lower()}', got '{item['chain']}'. Please check all categories for the current network.")
     return errors
 
+def rule_supported_routes_valid(data):
+    errors = []
+    for idx, item in enumerate(data):
+        routes = item.get("supportedRoutes")
+        if routes is None or not isinstance(routes, list):
+            continue
+
+        supported_chains = item.get("supportedChains")
+        supported_set = set(supported_chains) if isinstance(supported_chains, list) else None
+        seen = set()
+        route_order = []
+
+        for route_idx, route in enumerate(routes):
+            if not isinstance(route, dict):
+                continue  # JSON Schema reports the shape error.
+
+            source = route.get("sourceChain")
+            destination = route.get("destinationChain")
+            if not isinstance(source, str) or not isinstance(destination, str):
+                continue  # JSON Schema reports missing/non-string endpoints.
+
+            location = f"Item {idx}: supportedRoutes[{route_idx}]"
+            source_normalized = source.strip()
+            destination_normalized = destination.strip()
+            if source != source_normalized or destination != destination_normalized:
+                errors.append(f"{location}: route endpoints must be trimmed")
+            if not source_normalized or not destination_normalized:
+                errors.append(f"{location}: route endpoints must not be blank")
+            if source_normalized == destination_normalized:
+                errors.append(f"{location}: sourceChain and destinationChain must differ")
+
+            if supported_set is not None:
+                if source not in supported_set:
+                    errors.append(f"{location}: sourceChain '{source}' is not in supportedChains")
+                if destination not in supported_set:
+                    errors.append(f"{location}: destinationChain '{destination}' is not in supportedChains")
+
+            assets = route.get("assetSymbols")
+            if isinstance(assets, list):
+                assets_are_strings = all(isinstance(asset, str) for asset in assets)
+                if not assets_are_strings or any(asset != asset.strip() for asset in assets):
+                    errors.append(f"{location}: assetSymbols must contain trimmed strings")
+                if assets_are_strings and assets != sorted(assets):
+                    errors.append(f"{location}: assetSymbols must be sorted alphabetically")
+                if assets_are_strings and len(assets) != len(set(assets)):
+                    errors.append(f"{location}: assetSymbols must not contain duplicates")
+
+            fingerprint = json.dumps(route, sort_keys=True, separators=(",", ":"))
+            if fingerprint in seen:
+                errors.append(f"{location}: duplicate route object")
+            seen.add(fingerprint)
+            route_order.append((source, destination))
+
+        if route_order != sorted(route_order):
+            errors.append(f"Item {idx}: supportedRoutes must be sorted by sourceChain, then destinationChain")
+
+    return errors
+
+
 def has_unclosed_markdown(s: str) -> bool:
     if type(s) != str:
         return False
@@ -291,6 +350,7 @@ def main():
     rules.add_rule(rule_provider_casing_consistent)
     rules.add_rule(rule_slug_kebab_case)
     rules.add_rule(rule_chain_is_lowercase)
+    rules.add_rule(rule_supported_routes_valid)
 
     # Validate networks
     validator = Draft202012Validator(schema)


### PR DESCRIPTION
## Summary
Adds the missing `json-tools` schema, metadata, and permanent validation support for approved DBIP #2624.

This recreates the CI prerequisite that was missing from closed data PR #2725. That PR was closed as stale because `Generate JSON and validate` could not accept `supportedRoutes`; it was not rejected on scope.

## Changes
- Add optional `supportedRoutes` to the bridge JSON Schema
- Require `sourceChain` and `destinationChain` per route object
- Support optional non-empty, unique `assetSymbols`
- Reject extra route-object properties and exact duplicate objects
- Add `supportedRoutes` UI column metadata
- Add permanent validation for:
  - trimmed, non-blank endpoints
  - different source and destination
  - endpoint membership in populated `supportedChains`
  - trimmed, sorted, unique asset symbols
  - duplicate route objects
  - deterministic source/destination ordering

## Compatibility
The property is initially not in the bridge `required` header list. This keeps current `main` valid until the coordinated CSV data PR adds the column. After this tools PR merges, the data PR can pass isolated CI rather than repeat #2725's ordering failure.

## Validation
- `python3 -m py_compile tools/validate.py`
- JSON parsing for schema and metadata
- Positive and negative route-rule fixtures
- Direct Draft 2020-12 schema fixtures for valid shape, missing fields, extra fields, and empty assets
- `git diff --check`
- Confirmed no `.pyc` or `__pycache__` artifacts

## Economics
- DBIP #2624 has the `Approved` label and is compensated
- No active competing implementation PR exists
- No fee or funded transaction is required

## Payout
10 USDC to `0x06f44f4839fd5df4f4670036d028b29dec939363`.
