### PR TITLE
fix(schema): align wallet audit field (#2682)

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -802,17 +802,6 @@
     "cellType": null,
     "group": "capabilities"
   },
-  "audit": {
-    "key": "audit",
-    "label": "Audit Info",
-    "icon": "lucide:AudioWaveform",
-    "description": "Audit reports/sources.",
-    "filter": "searchableMultiSelect",
-    "sorting": "arrayLength",
-    "pinning": null,
-    "cellType": "arrayPopover",
-    "group": "security"
-  },
   "languages": {
     "key": "languages",
     "label": "Languages",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -538,7 +538,7 @@
         "staking": { "type": "boolean" },
         "price": { "type": ["string", "null"] },
         "support": { "type": ["array", "null"], "items": { "type": "string" } },
-        "audit": { "type": ["array", "null"], "items": { "type": "string" } },
+        "auditsPerformed": { "type": ["array", "null"], "items": { "type": "string" } },
         "languages": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -567,7 +567,7 @@
         "staking",
         "price",
         "support",
-        "audit",
+        "auditsPerformed",
         "languages",
         "starred",
         "actionButtons",


### PR DESCRIPTION
## Summary
Adds the minimal `json-tools` prerequisite for approved DBIP #2682 and the coordinated data PR #3563.

## Changes
- Rename `$defs.wallets.properties.audit` to `auditsPerformed`
- Rename the matching wallets required key
- Remove the redundant wallet-only `audit` column metadata
- Reuse the existing shared `auditsPerformed` metadata already used by bridges, oracles, and ramps

## Why this PR
The previous tools attempt #3114 was closed after CI issues and included an unrelated workflow rewrite. This recreation changes only the two schema/meta files needed by the approved DBIP.

## Validation
- Both JSON files parse successfully
- Every wallet required key exists in wallet properties
- Wallets contain `auditsPerformed` and no legacy `audit`
- Shared `auditsPerformed` metadata exists; legacy `audit` metadata is removed
- `git diff --check` passes

## Coordination
This targets `json-tools`. After merge, I will isolate existing data PR #3563 onto `upstream/main` so it contains only the 90 header renames and can pass CI.

No separate reward is claimed for this prerequisite; the approved DBIP's 10 USDC remains assigned once to the complete data implementation in #3563.
