### PR TITLE
Fix #2681: rename economicalSecurity to economicSecurity in schema

### DIFF
--- a/meta/columns.json
+++ b/meta/columns.json
@@ -384,9 +384,9 @@
     "cellType": null,
     "group": "security"
   },
-  "economicalSecurity": {
-    "key": "economicalSecurity",
-    "label": "Economical Security",
+  "economicSecurity": {
+    "key": "economicSecurity",
+    "label": "Economic Security",
     "icon": "lucide:ShieldHalf",
     "description": "Provides economic security guarantees.",
     "filter": "select",
@@ -395,9 +395,9 @@
     "cellType": null,
     "group": "security"
   },
-  "economicalSecurityNote": {
-    "key": "economicalSecurityNote",
-    "label": "Economical Security Note",
+  "economicSecurityNote": {
+    "key": "economicSecurityNote",
+    "label": "Economic Security Note",
     "icon": "lucide:ShieldEllipsis",
     "description": "Notes about economic security.",
     "filter": "select",

--- a/tools/schema.json
+++ b/tools/schema.json
@@ -213,8 +213,8 @@
           "items": { "type": "string" }
         },
         "decentralizationModel": { "type": ["string", "null"] },
-        "economicalSecurity": { "type": "boolean" },
-        "economicalSecurityNote": { "type": ["string", "null"] },
+        "economicSecurity": { "type": "boolean" },
+        "economicSecurityNote": { "type": ["string", "null"] },
         "sdk": { "type": ["array", "null"], "items": { "type": "string" } },
         "auditsPerformed": {
           "type": ["array", "null"],
@@ -237,8 +237,8 @@
         "additionalFeatures",
         "dataTypes",
         "decentralizationModel",
-        "economicalSecurity",
-        "economicalSecurityNote",
+        "economicSecurity",
+        "economicSecurityNote",
         "sdk",
         "auditsPerformed",
         "actionButtons",
@@ -281,8 +281,8 @@
         "txSpeedSla": { "type": ["string", "null"] },
         "throughputSla": { "type": ["string", "null"] },
         "price": { "type": ["string", "null"] },
-        "economicalSecurity": { "type": "boolean" },
-        "economicalSecurityNote": { "type": ["string", "null"] },
+        "economicSecurity": { "type": "boolean" },
+        "economicSecurityNote": { "type": ["string", "null"] },
         "auditsPerformed": {
           "type": ["array", "null"],
           "items": { "type": "string" }
@@ -311,8 +311,8 @@
         "txSpeedSla",
         "throughputSla",
         "price",
-        "economicalSecurity",
-        "economicalSecurityNote",
+        "economicSecurity",
+        "economicSecurityNote",
         "auditsPerformed",
         "decentralizationModel",
         "sdk",


### PR DESCRIPTION
## Fix #2681: rename economicalSecurity → economicSecurity in schema

### Problem
`economicalSecurity` and `economicalSecurityNote` misspell "economic security" — the standard term for a bridge or oracle's capital-at-stake / cost-to-corrupt guarantee. "Economical" means low-cost, an unrelated word. This affects all 219 bridges.csv and oracles.csv files (139 + 80).

### Fix
Renames both fields in the two places that define the canonical schema for bridges and oracles:
- `meta/columns.json`: key, label for both `economicSecurity` and `economicSecurityNote`
- `tools/schema.json`: property definitions and required-field lists for both bridges and oracles schemas

### Scope
Schema-only change. No CSV data files touched in this PR — those are covered separately in DBIP #2681's `main`-branch companion PR (#3562), which is currently blocked on this schema update landing first.

### Why resubmit
A prior attempt (#3261) was auto-closed for 3+ days of inactivity, not for a technical defect — no CI checks ever ran against it. This PR reproduces the identical, verified-correct diff.

Fixes #2681 (schema half).