### PR TITLE
Reject duplicate provider slugs before metadata generation

### DIFF
--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -571,6 +571,8 @@ def load_json_file(path: str) -> dict:
 
 
 def build_provider_index_by_name(providers: list[dict]) -> dict[str, dict]:
+    # Provider metadata is keyed by slug later; reject collisions before data is lost.
+    build_index_by_slug(providers, label="providers.csv")
     idx = {}
     for p in providers:
         name = p.get("name")

--- a/tools/test_provider_identity.py
+++ b/tools/test_provider_identity.py
@@ -1,0 +1,40 @@
+import unittest
+
+from csv_to_json import build_provider_index_by_name, build_provider_meta_from_names
+
+
+class ProviderIdentityTests(unittest.TestCase):
+    def test_duplicate_slugs_with_distinct_names_are_rejected(self):
+        providers = [
+            {"slug": "shared-id", "name": "Provider A"},
+            {"slug": "shared-id", "name": "Provider B"},
+        ]
+        with self.assertRaisesRegex(ValueError, "Duplicate slugs in providers.csv: shared-id"):
+            build_provider_index_by_name(providers)
+
+    def test_duplicate_names_with_distinct_slugs_are_still_rejected(self):
+        providers = [
+            {"slug": "provider-a", "name": "Shared Name"},
+            {"slug": "provider-b", "name": "Shared Name"},
+        ]
+        with self.assertRaisesRegex(ValueError, "Duplicate provider name"):
+            build_provider_index_by_name(providers)
+
+    def test_distinct_provider_identities_preserve_both_profiles(self):
+        providers = [
+            {"slug": "provider-a", "name": "Provider A"},
+            {"slug": "provider-b", "name": "Provider B"},
+        ]
+        index = build_provider_index_by_name(providers)
+        metadata = build_provider_meta_from_names(
+            index,
+            {"Provider A": {"apis"}, "Provider B": {"sdks"}},
+            network="algorand",
+        )
+        self.assertEqual(set(metadata), {"provider-a", "provider-b"})
+        self.assertEqual(metadata["provider-a"]["name"], "Provider A")
+        self.assertEqual(metadata["provider-b"]["categories"], ["sdks"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two providers with distinct names but the same slug currently pass the full validation pipeline, then one silently replaces the other in `meta.providers`. Reuse the existing slug-index validation before building the provider-name index so generation fails before metadata is lost.

Relates to #3628. This targets `json-tools`; no data rows, schema columns or metadata shapes change.

Validation:

- Three focused unittest cases pass: duplicate slug rejection, retained duplicate-name rejection, and preservation of distinct provider profiles.
- All three upstream pipeline commands pass against the current `main` dataset, producing and validating 155 network JSON files.
- In a scratch copy, changing Ankr's slug to `alchemy` previously passed all three commands while reducing Algorand provider metadata from 268 to 267 entries. The patched converter rejects it with `ValueError: Duplicate slugs in providers.csv: alchemy`.
- Existing warnings about chain-aware global listings in Lightning, Camino and Zilliqa also occur on the unmodified baseline; this change does not alter them.
- `git diff --check` passes.

Test command:

```sh
python3 -m unittest discover -s tools -p test_provider_identity.py -v
```

The DBIP requests consideration under the approved-proposal reward provision. No per-cell reward is claimed for this code-only patch.
