### PR TITLE
fix: preserve complete CSV records when sorting by slug

### DIFF
--- a/git-hooks/pre-commit.py
+++ b/git-hooks/pre-commit.py
@@ -140,7 +140,7 @@ def iter_csv(repo_root: Path) -> Iterable[Path]:
 def sort_csv_by_slug(repo_root: Path, delimiter: str = ",") -> None:
     """
     Sort CSV files by slug column without modifying quoting.
-    Uses the same naive delimiter parsing as rewrite_urls().
+    Keep quoted multiline fields together by sorting complete CSV records.
     """
     print("Sorting CSV files by slug")
 
@@ -153,31 +153,26 @@ def sort_csv_by_slug(repo_root: Path, delimiter: str = ",") -> None:
         if len(lines) <= 1:
             continue
 
-        header_line = lines[0].rstrip("\r\n")
-        header_parts = [h.strip().strip('"') for h in header_line.split(delimiter)]
+        reader = csv.reader(lines, delimiter=delimiter)
+        header_parts = [h.strip() for h in next(reader)]
+        header_line = "".join(lines[:reader.line_num]).rstrip("\r\n")
 
         if "slug" not in header_parts:
             continue
 
         slug_idx = header_parts.index("slug")
 
-        data_lines = lines[1:]
+        # line_num is the end of each logical record in the physical lines.
+        # Preserve the original text so CSV quoting is not rewritten.
+        records = []
+        previous_end = reader.line_num
+        for fields in reader:
+            raw_record = "".join(lines[previous_end:reader.line_num])
+            slug = fields[slug_idx].strip() if slug_idx < len(fields) else ""
+            records.append((slug, raw_record))
+            previous_end = reader.line_num
 
-        def slug_key(raw_line: str) -> str:
-            parts = raw_line.rstrip("\r\n").split(delimiter)
-
-            if slug_idx >= len(parts):
-                return ""
-
-            cell = parts[slug_idx].strip()
-
-            # normalize quoted slug for sorting only
-            if cell.startswith('"') and cell.endswith('"'):
-                cell = cell[1:-1]
-
-            return cell
-
-        rows_sorted = sorted(data_lines, key=slug_key)
+        rows_sorted = [raw for _, raw in sorted(records, key=lambda record: record[0])]
 
         with csv_file.open("w", newline="") as f:
             f.write(header_line + newline_style)

--- a/git-hooks/test_pre_commit.py
+++ b/git-hooks/test_pre_commit.py
@@ -1,0 +1,51 @@
+import contextlib
+import csv
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+spec = importlib.util.spec_from_file_location("pre_commit", Path(__file__).with_name("pre-commit.py"))
+hook = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hook)
+
+
+class SortCSVTests(unittest.TestCase):
+    def sort_text(self, text):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "example.csv"
+            path.write_bytes(text.encode())
+            with patch.object(hook.subprocess, "run"), contextlib.redirect_stdout(io.StringIO()):
+                hook.sort_csv_by_slug(Path(directory))
+            return path.read_bytes().decode()
+
+    def test_complete_records_preserve_quoted_values(self):
+        for nl in ("\n", "\r\n"):
+            with self.subTest(newline=repr(nl)):
+                header = "slug,additionalNotes" + nl
+                zulu = 'zulu,"line one' + nl + 'continuation, ""quoted"""' + nl
+                alpha = '"alpha",single' + nl
+                result = self.sort_text(header + zulu + alpha)
+                self.assertEqual(result, header + alpha + zulu)
+                self.assertEqual(list(csv.reader(io.StringIO(result, newline="")))[2][1],
+                                 'line one' + nl + 'continuation, "quoted"')
+                self.assertEqual(self.sort_text(result), result)
+
+    def test_slug_after_a_quoted_comma(self):
+        self.assertEqual(self.sort_text('notes,slug\n"a,b",zulu\n"z,y",alpha\n'),
+                         'notes,slug\n"z,y",alpha\n"a,b",zulu\n')
+
+    def test_single_line_rows_and_duplicate_keys(self):
+        self.assertEqual(self.sort_text('slug,notes\nzulu,last\nalpha,first\nalpha,second'),
+                         'slug,notes\nalpha,first\nalpha,second\nzulu,last\n')
+
+    def test_empty_header_only_and_no_slug_files_are_unchanged(self):
+        for text in ('', 'slug,notes\n', 'name,notes\nzulu,last\nalpha,first\n'):
+            with self.subTest(text=text):
+                self.assertEqual(self.sort_text(text), text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The pre-commit CSV sorter treats physical lines as rows. A quoted multiline `additionalNotes` value can be split apart and staged as corrupted CSV. Parse logical record boundaries with `csv.reader`, then sort and write the original record text so quoted values remain intact. This also fixes slug lookup when earlier columns contain quoted commas.

## Type of change

- Tooling bug fix with offline regression tests. No data rows or schema changes.

## Scope

- Networks affected: global pre-commit tooling.
- Categories affected: any CSV sorted by the hook.
- Files: `git-hooks/pre-commit.py` and `git-hooks/test_pre_commit.py` only.

## Validation

Related proposal: #3663. Please assess the proposal and reward eligibility before treating this draft as a bounty claim.

`python3 -m unittest discover -s git-hooks -p 'test_*.py' -v`

- Four test methods pass; the original code fails the multiline LF/CRLF cases and the quoted-comma column case.
- All 997 repository CSV files at base commit `e83cde059024fc5cfaf9881f5435c332905d54d4` were copied to temporary directories. The old and new sorters produce byte-identical results on that current corpus.
- `git diff --check` passes.
- No current multiline production rows or existing data corruption are claimed. This fixes a reproducible valid-input case before such data is submitted.
- The separately downloaded `json-tools` validation pipeline was not run. The existing permissive CSV parsing behavior is retained; strict parsing rejects an existing row in `references/offers/ramps.csv`, so tightening validation is outside this change.

## Validation checklist

- [x] Reviewed the Style Guide and the provider → offer → listing model; no schema or data contribution is included.
- New provider/network/pricing links: not applicable.
- Personal verification by the account owner: not performed.
- [x] The change was validated by executing a regression reproduction and tests, rather than submitted without execution.

## Authorship and reward eligibility

This change was prepared and tested by an AI coding assistant acting for the account owner, who has not personally reviewed it. It is a draft while the maintainers assess the linked proposal and whether it qualifies for the approved-DBIP reward in Discussion #41. No payment, award, or human review is claimed; a receiving address can follow an approved award.
