### PR TITLE
data: link Stork Somnia testnet deployment

### DIFF
--- a/listings/specific-networks/somnia/oracles.csv
+++ b/listings/specific-networks/somnia/oracles.csv
@@ -7,4 +7,4 @@ protofire-mainnet,,!offer:protofire,"[""[Price Feeds](https://docs.somnia.networ
 protofire-testnet,,!offer:protofire,"[""[Price Feeds](https://docs.somnia.network/developer/building-dapps/oracles/protofire-price-feeds)"",""[VRF](https://docs.somnia.network/developer/building-dapps/oracles/using-verifiable-randomness-vrf)""]",testnet,,,,,"[""AggregatorV3Interface compatibility"",""VRF v2.5""]","[""BTC/USD"",""ETH/USD"",""USDC/USD"",""Randomness""]",,,,,,
 scry-protocol-mainnet,,!offer:scry-protocol,,mainnet,,,,,,,,,,,,
 stork-mainnet,,!offer:stork,"[""[Docs](https://docs.stork.network/resources/contract-addresses/evm)"",""[Contract](https://explorer.somnia.network/address/0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62)""]",mainnet,,,,,,,,,,,,
-stork-testnet,,!offer:stork,,testnet,,,,,,,,,,,,
+stork-testnet,,!offer:stork,"[""[Docs](https://docs.stork.network/resources/contract-addresses/evm)"",""[Contract](https://shannon-explorer.somnia.network/address/0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62)""]",testnet,,,,,,,,,,,,


### PR DESCRIPTION
## Summary

Add network-specific Docs and Contract buttons to the existing `stork-testnet` oracle listing for Somnia. The row currently inherits Stork's generic links; the new buttons take users directly to the EVM deployment table and the Shannon testnet contract, matching the existing Somnia mainnet listing.

## Sources and verification

- [Stork official EVM deployments](https://docs.stork.network/resources/contract-addresses/evm#somnia) lists Somnia Testnet at `0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62` and links to the same explorer URL.
- [Somnia Shannon contract](https://shannon-explorer.somnia.network/address/0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62) returned HTTP 200 on 2026-09-06.
- Parsed the changed CSV: 9 records, 17 columns, exactly one changed cell (`stork-testnet.actionButtons`). JSON arrays, alphabetical slug order and canonical offer references remain valid. Original line endings are preserved. `git -c core.whitespace=cr-at-eol diff --check` passes (this CSV uses CRLF).
- Read the repository Style Guide and Oracles schema. The separate full JSON-generation pipeline was not run; upstream CI can validate the full dataset.

## Authorship and reward consideration

Prepared and source-checked by an AI coding assistant acting for the account owner. The account owner has not personally reviewed these links, so this does not attest to human verification. Please assess whether this contribution is eligible under Discussion #41; no award is assumed. A receiving address can be supplied if an award is approved.
