### PR TITLE
fix: enforce unique provider slugs before JSON metadata generation

### DIFF
--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -695,6 +695,8 @@ def main():
 
     # References
     providers = load_providers("references/providers/providers.csv")
+    # Validate unique provider slugs before building name index (fixes #3628)
+    build_index_by_slug(providers, label="providers.csv")
     provider_by_name = build_provider_index_by_name(providers)
     category_meta = load_json_file("meta/categories.json")
     column_meta = load_json_file("meta/columns.json")


### PR DESCRIPTION
## Summary

Fixes #3628.

Enforces unique provider `slug` values before JSON metadata generation, closing a validation gap where two providers sharing the same slug would silently overwrite each other in `meta.providers[slug]`.

## The change

One line added in `tools/csv_to_json.py` — call the existing `build_index_by_slug(providers, label="providers.csv")` helper before building the provider-name index. This reuses the existing collision detection and raises:

```
ValueError: Duplicate slugs in providers.csv: <slug>
```

before any JSON is written.

## Why this is safe

- Reuses the existing `build_index_by_slug` helper (already used for offer slugs) — no new validation logic.
- Keeps the existing duplicate-name check intact.
- No schema, column, or migration changes.
- Unique provider identities export exactly as before.

## Reproduction

The issue's scratch-copy test (Ankr slug changed to `alchemy`) previously returned exit code 0 across all three commands and silently lost a provider. With this fix, the validation fails fast with the error above, matching the behavior already applied to offer slugs.