### PR TITLE
Validate duplicate provider slugs before metadata generation

### DIFF
--- a/tests/test_csv_to_json.py
+++ b/tests/test_csv_to_json.py
@@ -1,0 +1,40 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "tools" / "csv_to_json.py"
+SPEC = importlib.util.spec_from_file_location("csv_to_json", MODULE_PATH)
+csv_to_json = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(csv_to_json)
+
+
+class ProviderSlugValidationTests(unittest.TestCase):
+    def test_rejects_duplicate_provider_slugs(self):
+        providers = [
+            {"name": "First Provider", "slug": "duplicate"},
+            {"name": "Second Provider", "slug": "duplicate"},
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError, r"Duplicate slugs in providers/providers\.csv: duplicate"
+        ):
+            csv_to_json.build_index_by_slug(
+                providers, label="providers/providers.csv"
+            )
+
+    def test_keeps_unique_provider_slugs(self):
+        providers = [
+            {"name": "First Provider", "slug": "first"},
+            {"name": "Second Provider", "slug": "second"},
+        ]
+
+        index = csv_to_json.build_index_by_slug(
+            providers, label="providers/providers.csv"
+        )
+
+        self.assertEqual(set(index), {"first", "second"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -695,6 +695,7 @@ def main():
 
     # References
     providers = load_providers("references/providers/providers.csv")
+    build_index_by_slug(providers, label="providers/providers.csv")
     provider_by_name = build_provider_index_by_name(providers)
     category_meta = load_json_file("meta/categories.json")
     column_meta = load_json_file("meta/columns.json")


### PR DESCRIPTION
Fixes #3628. Adds provider slug validation immediately after loading providers.csv, before provider metadata is constructed, so duplicate slugs fail explicitly instead of silently overwriting an entry in the generated metadata map. Adds focused regression tests for duplicate rejection and unique slugs.

Tests: `python -m unittest discover -s tests -v`; `python -m py_compile tools/csv_to_json.py tests/test_csv_to_json.py`; `git diff --check`.

Reward reference: Discussion #41, 10 USDC contingent on approved DBIP.

<!-- ari:f238fd42caae8abbb5f32b1dff730cf292945d7ebf2b87a6251574e3e8162adc -->