### PR TITLE
Fix validator markdown heuristics and validate providers.csv

### DIFF
--- a/tests/test_csv_to_json.py
+++ b/tests/test_csv_to_json.py
@@ -1,0 +1,40 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "tools" / "csv_to_json.py"
+SPEC = importlib.util.spec_from_file_location("csv_to_json", MODULE_PATH)
+csv_to_json = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(csv_to_json)
+
+
+class ProviderSlugValidationTests(unittest.TestCase):
+    def test_rejects_duplicate_provider_slugs(self):
+        providers = [
+            {"name": "First Provider", "slug": "duplicate"},
+            {"name": "Second Provider", "slug": "duplicate"},
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError, r"Duplicate slugs in providers/providers\.csv: duplicate"
+        ):
+            csv_to_json.build_index_by_slug(
+                providers, label="providers/providers.csv"
+            )
+
+    def test_keeps_unique_provider_slugs(self):
+        providers = [
+            {"name": "First Provider", "slug": "first"},
+            {"name": "Second Provider", "slug": "second"},
+        ]
+
+        index = csv_to_json.build_index_by_slug(
+            providers, label="providers/providers.csv"
+        )
+
+        self.assertEqual(set(index), {"first", "second"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,52 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "tools" / "validate.py"
+SPEC = importlib.util.spec_from_file_location("validate", MODULE_PATH)
+validate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate)
+
+
+class MarkdownValidationTests(unittest.TestCase):
+    def test_detects_single_star_after_bold(self):
+        self.assertTrue(validate.has_unclosed_markdown("**bold** and *unclosed"))
+
+    def test_underscore_in_url_is_not_markdown(self):
+        self.assertFalse(
+            validate.has_unclosed_markdown(
+                "https://subquery.network/doc/subquery_network/introduction"
+            )
+        )
+
+    def test_detects_unclosed_underscore_emphasis(self):
+        self.assertTrue(validate.has_unclosed_markdown("_unclosed emphasis"))
+
+
+class MarkdownLinkValidationTests(unittest.TestCase):
+    def test_accepts_balanced_parentheses_in_url(self):
+        self.assertTrue(
+            validate.is_markdown_link(
+                "[Docs](https://en.wikipedia.org/wiki/Chain_(blockchain))"
+            )
+        )
+
+    def test_rejects_trailing_text_and_unbalanced_url(self):
+        self.assertFalse(validate.is_markdown_link("[Docs](https://example.test) trailing"))
+        self.assertFalse(validate.is_markdown_link("[Docs](https://example.test/(broken)"))
+
+
+class ProviderSchemaTests(unittest.TestCase):
+    def test_provider_schema_targets_providers_table(self):
+        schema = validate.make_providers_schema({"$defs": {"providerMeta": {}}})
+        self.assertEqual(schema["required"], ["providers"])
+        self.assertEqual(schema["properties"]["providers"]["type"], "array")
+        self.assertEqual(
+            schema["properties"]["providers"]["items"],
+            {"$ref": "#/$defs/providerMeta"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -695,6 +695,7 @@ def main():
 
     # References
     providers = load_providers("references/providers/providers.csv")
+    build_index_by_slug(providers, label="providers/providers.csv")
     provider_by_name = build_provider_index_by_name(providers)
     category_meta = load_json_file("meta/categories.json")
     column_meta = load_json_file("meta/columns.json")

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -106,9 +106,15 @@ def has_unclosed_markdown(s: str) -> bool:
     # Check bold/italic/code
     if s.count("**") % 2 != 0:
         return True
-    if s.count("*") % 2 != 0 and s.count("**") == 0:  # single * for italic
+    # Bold markers contain two stars, so subtract their contribution before
+    # checking for an unmatched single-star marker.
+    if (s.count("*") - 2 * s.count("**")) % 2 != 0:
         return True
-    if s.count("_") % 2 != 0:
+    # Underscores are also valid in URLs and identifiers.  Only treat an
+    # underscore as emphasis when it appears as a markdown delimiter (rather
+    # than rejecting every odd underscore in ordinary text).
+    underscore_markers = re.findall(r"(?<![\w/])_(?!\s)|(?<!\s)_(?![\w/])", s)
+    if any(char.isspace() for char in s) and len(underscore_markers) % 2 != 0:
         return True
     if s.count("`") % 2 != 0:
         return True
@@ -129,8 +135,28 @@ def is_markdown_link(s: str) -> bool:
     if len(s) == 0:
         return False
 
-    pattern = r"(?:\[(?P<text>.*?)\])\((?P<link>.*?)\)"
-    return re.match(pattern, s) is not None
+    if not s.startswith("["):
+        return False
+    close_text = s.find("](")
+    if close_text < 1:
+        return False
+
+    # A destination may contain balanced parentheses.  The final character
+    # must close the link, not merely the first parenthesis in its URL.
+    destination = s[close_text + 2:]
+    if not destination or destination[-1] != ")":
+        return False
+    depth = 0
+    # The final character is the link's closing delimiter; only the prefix
+    # may contain balanced parentheses belonging to the URL.
+    for char in destination[:-1]:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
 
 def _data_categories(data):
     return {k for k in data.keys() if k not in ("columns", "meta", "schemaVersion")}
@@ -246,7 +272,9 @@ def check_rules_validation(rules_validator, data) -> bool:
     return not had_errors
 
 def check_validation(data, schema_validator, rules_validator) -> bool:
-    return check_schema_validation(schema_validator, data) and check_rules_validation(rules_validator, data)
+    schema_valid = check_schema_validation(schema_validator, data)
+    rules_valid = check_rules_validation(rules_validator, data)
+    return schema_valid and rules_valid
 
 def load_csv_folder(folder) -> dict:
     from csv_to_json import load_csv_to_dict_list, normalize
@@ -268,13 +296,15 @@ def load_csv_folder(folder) -> dict:
     return data
 
 def make_providers_schema(network_schema) -> dict:
+    """Build the root schema for references/providers/providers.csv."""
     providers_schema = copy.deepcopy(network_schema)
-    for definition in providers_schema['$defs'].keys():
-        if definition == "columns":
-            continue
-        if "chain" in providers_schema['$defs'][definition]['required']:
-            index = providers_schema['$defs'][definition]['required'].index("chain")
-            del providers_schema['$defs'][definition]['required'][index]
+    providers_schema["properties"] = {
+        "providers": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/providerMeta"},
+        }
+    }
+    providers_schema["required"] = ["providers"]
     return providers_schema
 
 def main():
@@ -303,7 +333,7 @@ def main():
             had_errors = True
 
     # Validate providers
-    providers_data = load_csv_folder("references/offers")
+    providers_data = load_csv_folder("references/providers")
     providers_schema = make_providers_schema(network_schema=schema)
     providers_validator = Draft202012Validator(providers_schema)
     if not check_validation(data=providers_data, schema_validator=providers_validator, rules_validator=rules):


### PR DESCRIPTION
Closes the validator correctness gaps described in #3656.

Changes:
- detect an unmatched single `*` even when bold markers are present;
- accept balanced parentheses in Markdown link destinations while rejecting truncation and trailing text;
- stop treating underscore-bearing URLs and provider handles as broken Markdown;
- validate `references/providers` with the provider schema and aggregate schema and rule errors;
- add offline regression tests.

Tests: `python -m unittest discover -s tests -v` (8 passed); `python -m py_compile tools/validate.py`; normalized 722-row providers.csv fixture against the provider schema and rules (0 rule errors).

Rewarded issue: https://github.com/Chain-Love/chain-love/issues/3656

<!-- ari:3fef9ae41fd109b89149ad61ad9eb91611418c8495e5efaafe719c4c9d6dfcb3 -->