### PR TITLE
data: add BitGo wallet support to Somnia

### DIFF
--- a/listings/specific-networks/somnia/services.csv
+++ b/listings/specific-networks/somnia/services.csv
@@ -1,6 +1,5 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 agent-kit,,!offer:agent-kit,,,,,,,,
-bitgo-wallet-as-a-service,,!offer:bitgo-wallet-as-a-service,"[""[Somnia Support](https://www.bitgo.com/en-in/resources/blog/bitgo-adds-support-for-somnia/)""]",,,,,,,
 chain-ide,,!offer:chain-ide,,,,,,,,
 pimlico-account-abstraction,,!offer:pimlico-account-abstraction,"[""[Docs](https://docs.somnia.network/developer/deployment-and-production/ecosystem/ecosystem-tools)""]",,,,,,,
 reown-free,,!offer:reown-free,,,,,,,,

--- a/listings/specific-networks/somnia/services.csv
+++ b/listings/specific-networks/somnia/services.csv
@@ -1,5 +1,6 @@
 slug,provider,offer,actionButtons,toolType,tag,price,planName,planType,description,starred
 agent-kit,,!offer:agent-kit,,,,,,,,
+bitgo-wallet-as-a-service,,!offer:bitgo-wallet-as-a-service,"[""[Somnia Support](https://www.bitgo.com/en-in/resources/blog/bitgo-adds-support-for-somnia/)""]",,,,,,,
 chain-ide,,!offer:chain-ide,,,,,,,,
 pimlico-account-abstraction,,!offer:pimlico-account-abstraction,"[""[Docs](https://docs.somnia.network/developer/deployment-and-production/ecosystem/ecosystem-tools)""]",,,,,,,
 reown-free,,!offer:reown-free,,,,,,,,

--- a/listings/specific-networks/somnia/wallets.csv
+++ b/listings/specific-networks/somnia/wallets.csv
@@ -1,6 +1,7 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 ambire-wallet,,!offer:ambire-wallet,,,,,,,,,,,,,,,,,,,
 binance-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
+bitgo-custody-wallet,,!offer:bitgo-custody-wallet,"[""[Somnia Support](https://www.bitgo.com/en-in/resources/blog/bitgo-adds-support-for-somnia/)""]",,,,,,,,,,,,,,,,,,
 clave-wallet,,!offer:clave-wallet,,,,,,,,,,,,,,,,,,,
 coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
 coinomi-wallet,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,

--- a/listings/specific-networks/somnia/wallets.csv
+++ b/listings/specific-networks/somnia/wallets.csv
@@ -1,7 +1,7 @@
 slug,provider,offer,actionButtons,openSource,supportedPlatforms,custodial,mfa,msig,hardware,keyExport,native,evm,tendermint,tokensSupport,staking,price,support,audit,languages,starred,tag
 ambire-wallet,,!offer:ambire-wallet,,,,,,,,,,,,,,,,,,,
 binance-wallet,,!offer:binance-wallet,,,,,,,,,,,,,,,,,,,
-bitgo-custody-wallet,,!offer:bitgo-custody-wallet,"[""[Somnia Support](https://www.bitgo.com/en-in/resources/blog/bitgo-adds-support-for-somnia/)""]",,,,,,,,,,,,,,,,,,
+bitgo-custody-wallet,,!offer:bitgo-custody-wallet,"[""[Website](https://www.bitgo.com/products/custody-wallets/)"",""[Somnia Support](https://www.bitgo.com/en-in/resources/blog/bitgo-adds-support-for-somnia/)""]",,,,,,,,,,,,,,,,,,
 clave-wallet,,!offer:clave-wallet,,,,,,,,,,,,,,,,,,,
 coin-wallet,,!offer:coin-wallet,,,,,,,,,,,,,,,,,,,
 coinomi-wallet,,!offer:coinomi-wallet,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Adds BitGo's Somnia support to the existing custody wallet and Wallet-as-a-Service listings.

Source:
https://www.bitgo.com/en-in/resources/blog/bitgo-adds-support-for-somnia/

BitGo confirms support for SOMI through qualified custody and enterprise-grade wallet infrastructure.

Only existing canonical offers are referenced. No unverified fields were added.

Rewards address:
0xe4064deaeA293c56059faCe1075A83FA23f4e1E4