### PR TITLE
fix: skip unchanged database releases

### DIFF
--- a/.github/workflows/build-and-relese-json.yaml
+++ b/.github/workflows/build-and-relese-json.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Compute checksum
         id: checksum
         run: |
-          sha=$(find release-assets -type f -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
+          sha=$(find release-assets -type f -name '*.json' -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
           echo "sha=$sha" >> $GITHUB_OUTPUT
           echo "$sha" > release-assets/checksum.txt
       
@@ -106,12 +106,14 @@ jobs:
           exit 0
       
       - name: Generate tag
+        if: steps.last.outputs.last != steps.checksum.outputs.sha
         id: tag
         run: |
           tag="json-$(date +%Y%m%d-%H%M%S)"
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Generate release index
+        if: steps.last.outputs.last != steps.checksum.outputs.sha
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -119,6 +121,7 @@ jobs:
           python generate_release_index.py
       
       - name: Create release
+        if: steps.last.outputs.last != steps.checksum.outputs.sha
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
## Summary

Fixes #3688.

The no-change check now hashes the JSON output instead of regenerated archives. The tag, release index, and release steps also use that check, so they are skipped when the database content is unchanged.

I reproduced the archive issue locally: changing only a file’s mtime changed the archive-inclusive checksum, while the JSON-only checksum stayed the same. I also parsed the updated workflow successfully with PyYAML.

## Type of change
- [ ] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: all
- Categories affected: all

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address: 0xe4064deaeA293c56059faCe1075A83FA23f4e1E4
