### PR TITLE
fix: preserve nullable booleans in SQLite

### DIFF
--- a/tools/create_sqlite.py
+++ b/tools/create_sqlite.py
@@ -100,7 +100,7 @@ def resolve_type(prop: JSONSchemaProperty) -> Tuple[str, bool]:
     if base == "number":
         return "REAL", nullable
     if base == "boolean":
-        return "INTEGER", False
+        return "INTEGER", nullable
     if base == "array":
         return "TEXT", True
 


### PR DESCRIPTION
## Summary

Fixes #3690.

This one-line change preserves JSON Schema nullability when boolean fields are mapped to SQLite. It fixes the mismatch where `agents.active` accepts null in the schema but becomes `INTEGER NOT NULL` in the generated database.

I verified the fix by generating the agents table and inserting a row with `active=None`. The insert now succeeds and reads back as SQL `NULL`.

## Type of change
- [ ] Add data rows
- [ ] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [ ] Documentation/metadata only

## Scope
- Networks affected: all
- Categories affected: agents and any future category with nullable booleans

## Validation checklist

- [x] **I followed the Style Guide and Column Definitions. I'm aware of what is `!provider` syntax, and that entities in `/networks` sub-folders inherits records from `/providers` folder**
- [x] **I personally opened and verified every new link I'm adding. I can confirm, that all the links I'm adding are valid.**
- [x] **If I added new entries - I personally confirmed that the provider I'm adding (modifying) currently supports the adjusted network(s). I've also verified that value in every cell I'm changing is correct according to my best understanding**
- [x] **This PR is not a blind AI-generated submission**

## Optional
- Rewards address: 0xe4064deaeA293c56059faCe1075A83FA23f4e1E4
