### PR TITLE
fix(hooks): use the Windows virtualenv interpreter

### DIFF
--- a/git-hooks/pre-commit.py
+++ b/git-hooks/pre-commit.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import io
+import os
 import shutil
 import subprocess
 import sys
@@ -217,7 +218,7 @@ def main() -> None:
             venv_dir = tmp_root / ".venv"
             run([python, "-m", "venv", str(venv_dir)])
 
-            venv_python = venv_dir / "bin" / "python"
+            venv_python = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
             python = str(venv_python)
 
             run([

--- a/git-hooks/test_pre_commit_venv.py
+++ b/git-hooks/test_pre_commit_venv.py
@@ -1,0 +1,57 @@
+"""Offline integration coverage for the hook's virtual environment interpreter."""
+import contextlib
+import importlib.util
+import io
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+class PreCommitVirtualenvTest(unittest.TestCase):
+    def test_dependency_install_and_validators_use_created_virtualenv(self):
+        spec = importlib.util.spec_from_file_location(
+            "pre_commit", Path(__file__).with_name("pre-commit.py")
+        )
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+        completed = []
+        real_run = hook.run
+
+        def overlay(url, dest, subpath):
+            (dest / "requirements.txt").write_text("", encoding="utf-8")
+            for script in hook.SCRIPTS:
+                (dest / script).write_text(
+                    "import sys\nassert sys.prefix != sys.base_prefix\n",
+                    encoding="utf-8",
+                )
+
+        def run(cmd, **kwargs):
+            real_run(cmd, **kwargs)
+            completed.append(list(cmd))
+
+        with tempfile.TemporaryDirectory(prefix="precommit-venv-test-") as root:
+            with (
+                patch.object(hook, "get_repo_root", return_value=Path(root)),
+                patch.object(hook, "checkout_index_tree"),
+                patch.object(hook, "download_and_extract", side_effect=overlay),
+                patch.object(hook, "run", side_effect=run),
+                patch.dict(os.environ, {
+                    "PIP_NO_INDEX": "1",
+                    "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+                }),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                hook.main()
+
+        self.assertEqual(len(completed), 5)
+        self.assertEqual(completed[1][1:4], ["-m", "pip", "install"])
+        self.assertEqual(
+            [Path(cmd[1]).name for cmd in completed[-3:]], hook.SCRIPTS
+        )
+        self.assertTrue(all(cmd[0] == completed[1][0] for cmd in completed[-3:]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
On Windows, the pre-commit hook creates `.venv/Scripts/python.exe` but then tries to install dependencies using `.venv/bin/python`, which raises `FileNotFoundError` before validation starts. Select the Windows interpreter path on `os.name == "nt"` and keep the existing POSIX path elsewhere.

Adds one offline integration test that exercises the hook's dependency branch using a real virtual environment, an empty requirements file, and three fixture validators. Each validator asserts that it runs inside a virtual environment. Downloads and index checkout are replaced with local fixtures; the interpreter and pip calls are real.

Validation on Windows:

- Reproduced the original `FileNotFoundError` at upstream commit `168495987009158d811c7bb41a3bb4b65d9a7a80` using the same offline fixture approach.
- `python -m unittest discover -s git-hooks -p test_pre_commit_venv.py -v` — passed (1 test).
- `git diff --check` — passed before commit.
- This is a tooling change; no CSV values or schemas are modified. The offline test does not run the production dataset validation pipeline. Linux/macOS execution has not been tested here.

Prepared and tested with an AI coding assistant under the account holder's authorization. If this tooling fix is eligible for a discretionary USDC/USDT contributor reward, please assess it under the project's rules. I understand that the published per-cell data reward and schema-DBIP reward do not automatically cover this repair; no payment has been agreed or is being claimed as owed.

If this tooling contribution qualifies for a reward, Ethereum mainnet receiving address: `0xb45A8D75cDf5C85c15d046D6ceA826Db4c034C61`.
