### PR TITLE
fix(csv2json): reject duplicate canonical offer listings

### DIFF
--- a/tools/csv_to_json.py
+++ b/tools/csv_to_json.py
@@ -259,29 +259,55 @@ def validate_no_offer_reference_conflicts(
     network_entities: list[dict],
     all_network_entities: list[dict],
 ) -> None:
-    network_entity_by_offer_and_chain = {}
-    for entity in network_entities:
+    def offer_chain_key(entity: dict) -> tuple[str, object] | None:
         offer_reference = entity.get("offer")
         if not is_offer_ref(offer_reference):
-            continue
+            return None
 
         chain = entity.get("chain")
         if isinstance(chain, str):
             chain = chain.strip().lower()
-        key = (get_ref_slug(offer_reference, OFFER_REF_PREFIX), chain)
-        network_entity_by_offer_and_chain[key] = entity
+        return (get_ref_slug(offer_reference, OFFER_REF_PREFIX), chain)
+
+    same_scope_conflicts = []
+    for scope_name, entities, scope_path in (
+        (
+            "network-specific",
+            network_entities,
+            f"listings/specific-networks/{network_name}/{category}.csv",
+        ),
+        ("all-networks", all_network_entities, f"listings/all-networks/{category}.csv"),
+    ):
+        first_by_offer_and_chain = {}
+        for entity in entities:
+            key = offer_chain_key(entity)
+            if key is None:
+                continue
+            first = first_by_offer_and_chain.get(key)
+            if first is not None:
+                offer_slug, chain = key
+                same_scope_conflicts.append(
+                    f"  - {scope_name} '{scope_path}': offer '{offer_slug}', "
+                    f"chain {chain!r} is referenced by both "
+                    f"listing slugs '{first.get('slug')}' and '{entity.get('slug')}'"
+                )
+            else:
+                first_by_offer_and_chain[key] = entity
+
+    network_entity_by_offer_and_chain = {}
+    for entity in network_entities:
+        key = offer_chain_key(entity)
+        if key is not None:
+            network_entity_by_offer_and_chain[key] = entity
 
     conflicts = []
     for entity in all_network_entities:
-        offer_reference = entity.get("offer")
-        if not is_offer_ref(offer_reference):
+        key = offer_chain_key(entity)
+        if key is None:
             continue
 
-        chain = entity.get("chain")
-        if isinstance(chain, str):
-            chain = chain.strip().lower()
-        offer_slug = get_ref_slug(offer_reference, OFFER_REF_PREFIX)
-        network_entity = network_entity_by_offer_and_chain.get((offer_slug, chain))
+        offer_slug, chain = key
+        network_entity = network_entity_by_offer_and_chain.get(key)
         if network_entity is None:
             continue
 
@@ -291,13 +317,21 @@ def validate_no_offer_reference_conflicts(
             f"all-networks slug '{entity.get('slug')}'"
         )
 
-    if conflicts:
+    if same_scope_conflicts or conflicts:
+        sections = []
+        if same_scope_conflicts:
+            sections.append(
+                "Duplicate canonical listings within one listing scope:\n"
+                + "\n".join(same_scope_conflicts)
+            )
+        if conflicts:
+            sections.append(
+                "Conflicting offer references across listing scopes:\n"
+                + "\n".join(conflicts)
+            )
         raise ValueError(
-            f"Conflicting offer references for network '{network_name}', "
-            f"category '{category}'. The same offer and chain cannot be listed in both "
-            f"listings/specific-networks/{network_name}/{category}.csv and "
-            f"listings/all-networks/{category}.csv:\n"
-            + "\n".join(conflicts)
+            f"Offer reference validation failed for network '{network_name}', "
+            f"category '{category}':\n" + "\n".join(sections)
         )
 
 

--- a/tools/test_csv_to_json.py
+++ b/tools/test_csv_to_json.py
@@ -1,0 +1,64 @@
+import unittest
+
+from csv_to_json import validate_no_offer_reference_conflicts
+
+
+class OfferReferenceConflictTests(unittest.TestCase):
+    def test_rejects_duplicate_offer_and_chain_in_network_scope(self):
+        with self.assertRaisesRegex(ValueError, "foo.*mainnet.*foo-a.*foo-b"):
+            validate_no_offer_reference_conflicts(
+                "apis",
+                "example-network",
+                [
+                    {"slug": "foo-a", "offer": "!offer:foo", "chain": "mainnet"},
+                    {"slug": "foo-b", "offer": "!offer:foo", "chain": "mainnet"},
+                ],
+                [],
+            )
+
+    def test_rejects_duplicate_offer_and_chain_in_all_network_scope(self):
+        with self.assertRaisesRegex(ValueError, "all-networks.*foo.*mainnet"):
+            validate_no_offer_reference_conflicts(
+                "apis",
+                "example-network",
+                [],
+                [
+                    {"slug": "foo-a", "offer": "!offer:foo", "chain": "mainnet"},
+                    {"slug": "foo-b", "offer": "!offer:foo", "chain": "mainnet"},
+                ],
+            )
+
+    def test_accepts_same_offer_on_different_chains(self):
+        validate_no_offer_reference_conflicts(
+            "apis",
+            "example-network",
+            [
+                {"slug": "foo-mainnet", "offer": "!offer:foo", "chain": "mainnet"},
+                {"slug": "foo-testnet", "offer": "!offer:foo", "chain": "testnet"},
+            ],
+            [],
+        )
+
+    def test_accepts_different_offers_on_same_chain(self):
+        validate_no_offer_reference_conflicts(
+            "apis",
+            "example-network",
+            [
+                {"slug": "foo", "offer": "!offer:foo", "chain": "mainnet"},
+                {"slug": "bar", "offer": "!offer:bar", "chain": "mainnet"},
+            ],
+            [],
+        )
+
+    def test_preserves_cross_scope_conflict_detection(self):
+        with self.assertRaisesRegex(ValueError, "across listing scopes"):
+            validate_no_offer_reference_conflicts(
+                "apis",
+                "example-network",
+                [{"slug": "foo-specific", "offer": "!offer:foo", "chain": "mainnet"}],
+                [{"slug": "foo-global", "offer": "!offer:foo", "chain": "mainnet"}],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #3702.

The existing converter detects the same `!offer:<slug>` + chain pair across the network-specific and all-networks scopes, but a dictionary assignment silently replaces an earlier row when two listing slugs reference the same canonical offer on the same chain within one scope.

This change:

- validates both listing scopes before output generation;
- reports the category, scope, canonical offer, chain, and both conflicting listing slugs;
- preserves the existing cross-scope conflict check;
- adds five focused unittest cases for duplicates, distinct chains/offers, and cross-scope conflicts.

## Verification

- `PYTHONPATH=tools python3 -m unittest discover -s tools -p 'test_*.py'`
- `python3 -m py_compile tools/csv_to_json.py`
- `git diff --check`

## Reward address

USDC — Ethereum Mainnet — `0x8058c3f91882E74aEd7e903309B9F9464104b9c3`
