### PR TITLE
data(filecoin): add Banxa docs link

### DIFF
--- a/listings/specific-networks/filecoin/ramps.csv
+++ b/listings/specific-networks/filecoin/ramps.csv
@@ -1,6 +1,6 @@
 slug,provider,offer,actionButtons,kycLevel,paymentMethods,bannedCountries,aggregator,auditsPerformed,deliveryType,tag
 alchemy-pay,,!offer:alchemy-pay,,,,,,,,
-banxa,,!offer:banxa,,,,,,,,
+banxa,,!offer:banxa,"[""[Docs](https://docs.banxa.com/products/hosted-checkout/docs/reference/supported-cryptocurrencies-and-blockchains)""]",,,,,,,
 btcdirect,,!offer:btcdirect,,,,,,,,
 coinbase-onramp,,!offer:coinbase-onramp,,,,,,,,
 meld,,!offer:meld,,,,,,,,


### PR DESCRIPTION
## Summary

Adds Banxa's official supported cryptocurrencies and blockchains documentation to the existing Filecoin ramp listing.

## Type of change
- [ ] Add data rows
- [x] Update data rows
- [ ] Remove data rows
- [ ] Schema change
- [x] Documentation/metadata only

## Scope
- Network affected: Filecoin
- Category affected: ramps
- Improved non-null cells: 1

## Verification
- Banxa's official documentation lists FIL on the Filecoin network as supported for Buy.
- The change fills only the existing `actionButtons` cell for `banxa`.
- The CSV row keeps the existing schema width.
- Open PR search immediately before submission found no competing Banxa/Filecoin PR.

## Source
- https://docs.banxa.com/products/hosted-checkout/docs/reference/supported-cryptocurrencies-and-blockchains

## Transparency
Prepared with AI assistance under the account owner's authorization. The source, target row, and open-PR overlap were checked before submission.

## Reward
Reward address: pending account-owner confirmation; no address has been invented or substituted.