### PR TITLE
fix(ci): handle discord invite paths in link checker

### DIFF
--- a/.github/workflows/link-check-analysis.yaml
+++ b/.github/workflows/link-check-analysis.yaml
@@ -96,6 +96,9 @@ jobs:
               if platform == "github":
                   return f"https://github.com/{v}"
               if platform == "discord":
+                  if v.startswith("invite/"):
+                      invite_code = v[len("invite/"):]
+                      return f"https://discord.com/invite/{invite_code}"
                   return f"https://discord.gg/{v}"
               if platform == "telegram":
                   return f"https://t.me/{v}"
@@ -103,7 +106,14 @@ jobs:
                   return f"https://www.linkedin.com/{v}"
           
               return ""
-          
+
+          assert provider_handle_to_url("discord", "invite/1inch") == "https://discord.com/invite/1inch"
+          assert provider_handle_to_url("discord", "invite/Cun2VpsdjF") == "https://discord.com/invite/Cun2VpsdjF"
+          assert provider_handle_to_url("discord", "chainlove") == "https://discord.gg/chainlove"
+          assert provider_handle_to_url("discord", "@chainlove") == "https://discord.gg/chainlove"
+          assert provider_handle_to_url("discord", "https://discord.com/invite/chainlove") == "https://discord.com/invite/chainlove"
+          assert provider_handle_to_url("discord", "") == ""
+
           def unique(seq: list[str]) -> list[str]:
               seen: set[str] = set()
               out: list[str] = []


### PR DESCRIPTION
## Summary

The link-check analysis workflow currently converts every non-URL `discord` provider value to:

`https://discord.gg/{value}`

Some existing provider records use the valid path-style format `invite/<code>`, for example:

- `invite/1inch`
- `invite/Cun2VpsdjF`

This currently produces invalid URLs such as:

`https://discord.gg/invite/1inch`

This PR updates the helper to support both existing formats:

- `invite/<code>` -> `https://discord.com/invite/<code>`
- `<code>` -> `https://discord.gg/<code>`

Assertions were added to prevent regressions.

## Type of change

- [x] CI/workflow change only (no data or schema change)

## Scope

- Networks affected: global CI
- Categories affected: none
- File changed: `.github/workflows/link-check-analysis.yaml`
- No provider, offer, network, or listing data was changed.

## Links

- Related issue(s) / DBIP: Not applicable. An issue is not required for this workflow fix.

## Validation evidence

- YAML parsing passes.
- Embedded Python blocks compile successfully.
- Helper assertions pass.
- All 11 current `invite/...` provider values are converted to `https://discord.com/invite/...`.
- No generated URL starts with `https://discord.gg/invite/`.
- `git diff --check` passes.

## Validation checklist

- [ ] I have starred the Chain.Love repository.
- [ ] I followed the Style Guide and Column Definitions.
- [ ] I personally opened and verified every new link I am adding.
- [ ] If I added new entries, I verified the affected provider and network data.

## Optional

- Rewards address: N/A