### PR TITLE
fix: preserve category defaultSorting in SQLite exports

### DIFF
--- a/tests/test_sqlite_category_sorting.py
+++ b/tests/test_sqlite_category_sorting.py
@@ -1,0 +1,30 @@
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+from create_sqlite import build_meta_tables, insert_batch
+
+
+class CategorySortingTests(unittest.TestCase):
+    def test_default_sorting_survives_sqlite_projection(self):
+        table = next(t for t in build_meta_tables() if t.name == "__meta_categories")
+        with sqlite3.connect(":memory:") as conn:
+            conn.execute(table.create_sql())
+            insert_batch(conn, table, [
+                {"network": "algorand", "key": "agents", "label": "Agents",
+                 "defaultSorting": "rank", "position": 0},
+                {"network": "algorand", "key": "apis", "label": "APIs",
+                 "position": 1},
+            ])
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(__meta_categories)")}
+            self.assertIn("defaultSorting", columns)
+            rows = conn.execute(
+                'SELECT key, "defaultSorting" FROM __meta_categories ORDER BY position'
+            ).fetchall()
+            self.assertEqual(rows, [("agents", "rank"), ("apis", None)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/create_sqlite.py
+++ b/tools/create_sqlite.py
@@ -151,6 +151,7 @@ def build_meta_tables() -> List[Table]:
                 Column("label", "TEXT", True),
                 Column("icon", "TEXT", True),
                 Column("description", "TEXT", True),
+                Column("defaultSorting", "TEXT", True),
                 Column("columns_order", "TEXT", True),
                 Column("position", "INTEGER", False),
             ],


### PR DESCRIPTION
## Summary
SQLite exports currently drop the existing `agents.defaultSorting = rank` setting. Add nullable `defaultSorting` to `__meta_categories` so the existing insertion path retains it; unspecified categories remain NULL.

Closes #3785. Targets `json-tools`. This changes the SQLite export schema only, with no CSV/data-provider claims.

## Validation
`python -m unittest discover -s tests -v` passes. The regression fails on upstream, then verifies that both `rank` and an absent setting survive SQLite insertion correctly. `git diff --check` passes.

## Contribution notes
The repository has been starred and forked. The Style Guide and contribution instructions were reviewed. The change was prepared and tested with AI assistance. No new external provider links or network availability claims are introduced. This PR accompanies the DBIP for schema review.

Reward consideration: approved-DBIP provision of Discussion #41, not a per-cell data claim. USDC ERC20 / Ethereum mainnet: `0x823603278de86e0c4b92a91b4b5dc3db6e7209e2`.
