### PR TITLE
fix: retain source schemaVersion in NDJSON and SQLite exports

### DIFF
--- a/tests/test_export_schema_version.py
+++ b/tests/test_export_schema_version.py
@@ -1,0 +1,49 @@
+import json
+import sqlite3
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+import create_ndjson
+import create_sqlite
+
+
+class ExportSchemaVersionTests(unittest.TestCase):
+    def test_versions_survive_archive_and_database_exports(self):
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            schema = root / "schema.json"
+            schema.write_text('{"properties": {}, "$defs": {}}', encoding="utf-8")
+            with patch.object(create_ndjson, "JSON_DIR", name):
+                for network, version in [("first", "2.0.0"), ("second", "3.0.0"), ("legacy", None)]:
+                    raw = {"meta": {"categories": {"apis": {"label": "APIs"}}}}
+                    if version is not None:
+                        raw["schemaVersion"] = version
+                    create_ndjson.write_tar(network, raw)
+            with tarfile.open(root / "first-ndjson.tar.gz") as archive:
+                self.assertIn("meta/document.ndjson", archive.getnames())
+                self.assertEqual(json.load(archive.extractfile("meta/document.ndjson")),
+                                 {"schemaVersion": "2.0.0"})
+            with patch.object(create_sqlite, "SCHEMA_FILE", str(schema)), \
+                 patch.object(create_sqlite, "DATA_DIR", root):
+                create_sqlite.main()
+            for network, expected in [("app", [("first", "2.0.0"), ("second", "3.0.0")]),
+                                      ("first", [("first", "2.0.0")]), ("legacy", [])]:
+                db = root / f"{network}.db"
+                with tarfile.open(root / f"{network}.db.tar.gz") as archive:
+                    db.write_bytes(archive.extractfile(db.name).read())
+                conn = sqlite3.connect(db)
+                try:
+                    self.assertEqual(conn.execute(
+                        'SELECT network, schemaVersion FROM __meta_documents ORDER BY network'
+                    ).fetchall(), expected)
+                finally:
+                    conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/create_ndjson.py
+++ b/tools/create_ndjson.py
@@ -142,6 +142,10 @@ def write_tar(network: str, raw: RawRoot) -> None:
 
     with tarfile.open(tar_path, "w:gz", compresslevel=9) as tar:
 
+        version = raw.get("schemaVersion")
+        if isinstance(version, str):
+            write_ndjson_file(tar, "meta/document.ndjson", [{"schemaVersion": version}])
+
         # --- DATA ---
         for category, items in data.items():
             write_ndjson_file(tar, f"{category}.ndjson", items)

--- a/tools/create_sqlite.py
+++ b/tools/create_sqlite.py
@@ -144,6 +144,10 @@ def build_tables(schema: JSONSchemaRoot) -> List[Table]:
 def build_meta_tables() -> List[Table]:
     return [
         Table(
+            "__meta_documents",
+            [Column("network", "TEXT", False), Column("schemaVersion", "TEXT", False)],
+        ),
+        Table(
             "__meta_categories",
             [
                 Column("network", "TEXT", False),
@@ -310,6 +314,7 @@ def main():
 
                 # --- process meta/*.ndjson ---
                 meta_tables = {
+                    "document": table_map["__meta_documents"],
                     "categories": table_map["__meta_categories"],
                     "columns": table_map["__meta_columns"],
                     "providers": table_map["__meta_providers"],


### PR DESCRIPTION
## Summary
The JSON-to-NDJSON export drops the source `schemaVersion`, leaving standalone NDJSON and SQLite consumers without the document's declared version. Write one optional `meta/document.ndjson` record and import it into `__meta_documents(network, schemaVersion)` in the aggregate and per-network SQLite databases.

Closes #3786. Targets `json-tools`. Legacy archives remain readable and receive no inferred version. Existing data and category files are unchanged. This is an additive export-schema proposal; no CSV schema/data rows are changed.

## Validation
`python -m unittest discover -s tests -v` passes. The network-free integration test failed against upstream, then passed with the patch: it builds NDJSON archives with two distinct source versions and a legacy archive, runs the real SQLite exporter/compression, and verifies the aggregate and per-network databases. `git diff --check` passes. The full network-enrichment release pipeline was not run.

## Contribution notes
The repository has been starred and forked. The Style Guide and contribution instructions were reviewed. The change was prepared and tested with AI assistance. No new external provider links or network availability claims are introduced. This PR accompanies the DBIP for schema review.

Reward consideration: approved-DBIP provision of Discussion #41, not a per-cell data claim. USDC ERC20 / Ethereum mainnet: `0x823603278de86e0c4b92a91b4b5dc3db6e7209e2`.
